### PR TITLE
Add Pydantic models to news scanner module

### DIFF
--- a/src/modules/events/news_scanner/dedup.py
+++ b/src/modules/events/news_scanner/dedup.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from dataclasses import asdict
 
 import boto3
 from botocore.exceptions import ClientError
 
-from .serp import SerpResponse
+from .models import SerpResponse
 
 logger = logging.getLogger(__name__)
 

--- a/src/modules/events/news_scanner/handler.py
+++ b/src/modules/events/news_scanner/handler.py
@@ -7,7 +7,6 @@ Two-layer architecture:
 
 from __future__ import annotations
 
-import json
 import logging
 from datetime import datetime, timezone
 from typing import Any
@@ -16,7 +15,10 @@ import boto3
 import yaml
 from botocore.exceptions import ClientError
 
+from src.cli.models import TickerRegistry, TickerRegistryEntry
+
 from . import dedup, serp, triage
+from .models import NewsScannerConfig
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -25,16 +27,6 @@ BUCKET = "praxis-copilot"
 CONFIG_KEY = "config/news.yaml"
 REGISTRY_KEY = "config/ticker_registry.yaml"
 
-# Default config values
-DEFAULTS = {
-    "enabled": True,
-    "serp_api": "serpapi",
-    "serp_api_key_param": "/praxis/serpapi_key",
-    "results_per_ticker": 10,
-    "lookback_hours": 24,
-    "market_hours_only": True,
-}
-
 
 def _load_yaml_from_s3(s3_client: boto3.client, key: str) -> dict[str, Any]:
     """Load and parse a YAML file from S3."""
@@ -42,7 +34,7 @@ def _load_yaml_from_s3(s3_client: boto3.client, key: str) -> dict[str, Any]:
     return yaml.safe_load(obj["Body"].read().decode()) or {}
 
 
-def _load_config(s3_client: boto3.client) -> dict[str, Any]:
+def _load_config(s3_client: boto3.client) -> NewsScannerConfig:
     """Load news scanner config from S3, with defaults."""
     try:
         config = _load_yaml_from_s3(s3_client, CONFIG_KEY)
@@ -56,14 +48,14 @@ def _load_config(s3_client: boto3.client) -> dict[str, Any]:
     except (yaml.YAMLError, ValueError) as e:
         logger.warning("Failed to parse %s (%s), using defaults", CONFIG_KEY, e)
         config = {}
-    merged = {**DEFAULTS, **config}
-    return merged
+    return NewsScannerConfig(**config)
 
 
-def _load_ticker_registry(s3_client: boto3.client) -> dict[str, dict[str, Any]]:
+def _load_ticker_registry(s3_client: boto3.client) -> dict[str, TickerRegistryEntry]:
     """Load ticker registry from S3. Returns dict of ticker -> config."""
-    registry = _load_yaml_from_s3(s3_client, REGISTRY_KEY)
-    return registry.get("tickers", {})
+    raw = _load_yaml_from_s3(s3_client, REGISTRY_KEY)
+    registry = TickerRegistry.model_validate(raw)
+    return registry.tickers
 
 
 def _get_serp_api_key(ssm_client: boto3.client, param_name: str) -> str:
@@ -107,12 +99,12 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
     # Load config
     config = _load_config(s3)
-    if not config["enabled"]:
+    if not config.enabled:
         logger.info("News scanner disabled via config")
         return {"status": "disabled"}
 
     # Check market hours
-    if config["market_hours_only"] and not _is_market_hours(now):
+    if config.market_hours_only and not _is_market_hours(now):
         logger.info("Outside market hours, skipping sweep")
         return {"status": "skipped", "reason": "outside_market_hours"}
 
@@ -124,13 +116,13 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
     # Get SERP API key from SSM
     try:
-        api_key = _get_serp_api_key(ssm, config["serp_api_key_param"])
+        api_key = _get_serp_api_key(ssm, config.serp_api_key_param)
     except ClientError as e:
         logger.error("Failed to retrieve SERP API key from SSM: %s", e)
         return {"status": "error", "reason": "ssm_key_retrieval_failed"}
 
     # Initialize SERP provider
-    provider = serp.get_provider(config["serp_api"], api_key)
+    provider = serp.get_provider(config.serp_api, api_key)
 
     # --- Layer 1: SERP Sweep ---
     logger.info("Starting SERP sweep for %d tickers", len(tickers))
@@ -139,7 +131,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     for ticker, ticker_config in tickers.items():
         try:
             resp = serp.sweep_ticker(
-                provider, ticker, ticker_config, num_results=config["results_per_ticker"]
+                provider, ticker, ticker_config, num_results=config.results_per_ticker
             )
             responses[ticker] = resp
         except Exception:

--- a/src/modules/events/news_scanner/models.py
+++ b/src/modules/events/news_scanner/models.py
@@ -1,0 +1,86 @@
+"""Pydantic models for the news scanner module."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+# --- SERP models (replacing dataclasses in serp.py) ---
+
+
+class SerpResult(BaseModel):
+    """A single search result from a SERP query."""
+
+    headline: str
+    url: str
+    snippet: str
+    source: str
+    published: str | None = None
+
+
+class SerpResponse(BaseModel):
+    """Response from a SERP query for a single ticker."""
+
+    ticker: str
+    query: str
+    results: list[SerpResult] = Field(default_factory=list)
+
+
+# --- Triage models ---
+
+
+class Monitor(BaseModel):
+    """A monitor definition relevant to a ticker."""
+
+    id: str
+    description: str = ""
+    listen: list[str] = Field(default_factory=list)
+
+
+class Significance(str, Enum):
+    """Significance level for a material news item."""
+
+    high = "high"
+    medium = "medium"
+    low = "low"
+
+
+class MaterialItem(BaseModel):
+    """A single material news item from the triage digest."""
+
+    ticker: str
+    headline: str
+    url: str
+    relevance: str
+    related_monitors: list[str] = Field(default_factory=list)
+    significance: Significance
+
+
+class TriageDigest(BaseModel):
+    """Triage digest output from the Sonnet agent."""
+
+    material: list[MaterialItem] = Field(default_factory=list)
+    nothing_material: list[str] = Field(default_factory=list)
+    # Preserved for error/debug cases
+    raw: str | None = Field(None, alias="_raw")
+    parse_error: bool = Field(False, alias="_parse_error")
+    error: str | None = Field(None, alias="_error")
+
+    model_config = {"populate_by_name": True}
+
+
+# --- Handler config ---
+
+
+class NewsScannerConfig(BaseModel):
+    """News scanner configuration loaded from S3."""
+
+    enabled: bool = True
+    serp_api: str = "serpapi"
+    serp_api_key_param: str = "/praxis/serpapi_key"
+    results_per_ticker: int = 10
+    lookback_hours: int = 24
+    market_hours_only: bool = True

--- a/src/modules/events/news_scanner/serp.py
+++ b/src/modules/events/news_scanner/serp.py
@@ -5,34 +5,17 @@ from __future__ import annotations
 import logging
 import time
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
 from typing import Any
 
 import requests
 
+from src.cli.models import TickerRegistryEntry
+
+from .models import SerpResponse, SerpResult
+
 logger = logging.getLogger(__name__)
 
 SERPAPI_ENDPOINT = "https://serpapi.com/search"
-
-
-@dataclass
-class SerpResult:
-    """A single search result from a SERP query."""
-
-    headline: str
-    url: str
-    snippet: str
-    source: str
-    published: str | None = None
-
-
-@dataclass
-class SerpResponse:
-    """Response from a SERP query for a single ticker."""
-
-    ticker: str
-    query: str
-    results: list[SerpResult] = field(default_factory=list)
 
 
 class SerpProvider(ABC):
@@ -100,24 +83,23 @@ def get_provider(provider_name: str, api_key: str) -> SerpProvider:
     return cls(api_key=api_key)
 
 
-def build_queries(ticker: str, ticker_config: dict[str, Any]) -> list[str]:
+def build_queries(ticker: str, ticker_config: TickerRegistryEntry) -> list[str]:
     """Build search queries for a ticker from its registry config.
 
     Uses news_queries from ticker registry if available,
     otherwise falls back to '"{company_name}" OR "{ticker}"'.
     """
-    custom_queries = ticker_config.get("news_queries")
-    if custom_queries:
-        return custom_queries
+    if ticker_config.news_queries:
+        return ticker_config.news_queries
 
-    company_name = ticker_config.get("name", ticker)
+    company_name = ticker_config.name or ticker
     return [f'"{company_name}" OR "{ticker}"']
 
 
 def sweep_ticker(
     provider: SerpProvider,
     ticker: str,
-    ticker_config: dict[str, Any],
+    ticker_config: TickerRegistryEntry,
     num_results: int = 10,
 ) -> SerpResponse:
     """Run SERP sweep for a single ticker. Merges results from all queries."""

--- a/src/modules/events/news_scanner/triage.py
+++ b/src/modules/events/news_scanner/triage.py
@@ -6,7 +6,6 @@ Produces a triaged digest identifying material news.
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Any
 
@@ -15,7 +14,7 @@ import boto3
 import yaml
 from botocore.exceptions import ClientError
 
-from .serp import SerpResponse
+from .models import Monitor, SerpResponse, TriageDigest
 
 logger = logging.getLogger(__name__)
 
@@ -80,9 +79,9 @@ def _load_thesis_summary(s3_client: boto3.client, ticker: str) -> str | None:
         return None
 
 
-def _load_monitors(s3_client: boto3.client, ticker: str) -> list[dict[str, Any]]:
+def _load_monitors(s3_client: boto3.client, ticker: str) -> list[Monitor]:
     """Load active monitor definitions that listen to this ticker."""
-    monitors: list[dict[str, Any]] = []
+    monitors: list[Monitor] = []
     try:
         # List all monitor config files (paginated)
         paginator = s3_client.get_paginator("list_objects_v2")
@@ -99,11 +98,11 @@ def _load_monitors(s3_client: boto3.client, ticker: str) -> list[dict[str, Any]]
                 listen_list = monitor.get("listen", [])
                 for listen_item in listen_list:
                     if isinstance(listen_item, str) and listen_item.startswith(f"{ticker}:"):
-                        monitors.append({
-                            "id": monitor.get("id", key.split("/")[-1].replace(".yaml", "")),
-                            "description": monitor.get("description", ""),
-                            "listen": listen_list,
-                        })
+                        monitors.append(Monitor(
+                            id=monitor.get("id", key.split("/")[-1].replace(".yaml", "")),
+                            description=monitor.get("description", ""),
+                            listen=listen_list,
+                        ))
                         break
     except ClientError as e:
         logger.error("S3 error loading monitors for %s: %s", ticker, e)
@@ -115,7 +114,7 @@ def _load_monitors(s3_client: boto3.client, ticker: str) -> list[dict[str, Any]]
 def _build_user_prompt(
     changed_responses: dict[str, SerpResponse],
     thesis_summaries: dict[str, str | None],
-    monitors: dict[str, list[dict[str, Any]]],
+    monitors: dict[str, list[Monitor]],
 ) -> str:
     """Build the user prompt with all context for the triage agent."""
     sections: list[str] = []
@@ -147,7 +146,7 @@ def _build_user_prompt(
         if ticker_monitors:
             section += "### Active Monitors\n"
             for m in ticker_monitors:
-                section += f"- **{m['id']}**: {m['description']}\n"
+                section += f"- **{m.id}**: {m.description}\n"
             section += "\n"
 
         sections.append(section)
@@ -158,7 +157,7 @@ def _build_user_prompt(
 def run_triage(
     s3_client: boto3.client,
     changed_responses: dict[str, SerpResponse],
-) -> dict[str, Any]:
+) -> TriageDigest:
     """Run Sonnet triage on changed headlines.
 
     Args:
@@ -166,14 +165,14 @@ def run_triage(
         changed_responses: dict of ticker -> SerpResponse for tickers with changed content
 
     Returns:
-        Parsed triage digest as a dict
+        Parsed triage digest
     """
     if not changed_responses:
-        return {"material": [], "nothing_material": []}
+        return TriageDigest()
 
     # Gather context
     thesis_summaries: dict[str, str | None] = {}
-    monitors: dict[str, list[dict[str, Any]]] = {}
+    monitors: dict[str, list[Monitor]] = {}
 
     for ticker in changed_responses:
         thesis_summaries[ticker] = _load_thesis_summary(s3_client, ticker)
@@ -198,11 +197,17 @@ def run_triage(
         )
     except anthropic.APIError as e:
         logger.error("Anthropic API call failed: %s", e)
-        return {"material": [], "nothing_material": list(changed_responses.keys()), "_error": str(e)}
+        return TriageDigest(
+            nothing_material=list(changed_responses.keys()),
+            _error=str(e),
+        )
 
     if not response.content or not hasattr(response.content[0], "text"):
         logger.error("Anthropic API returned empty content")
-        return {"material": [], "nothing_material": list(changed_responses.keys()), "_error": "empty_response"}
+        return TriageDigest(
+            nothing_material=list(changed_responses.keys()),
+            _error="empty_response",
+        )
 
     raw_text = response.content[0].text
 
@@ -218,19 +223,21 @@ def run_triage(
         text = "\n".join(lines)
 
     try:
-        digest = yaml.safe_load(text)
-        if not isinstance(digest, dict):
-            digest = {"material": [], "nothing_material": [], "_raw": raw_text}
+        parsed = yaml.safe_load(text)
+        if not isinstance(parsed, dict):
+            return TriageDigest(_raw=raw_text)
+        return TriageDigest.model_validate(parsed)
     except yaml.YAMLError:
         logger.error("Failed to parse triage YAML response")
-        digest = {"material": [], "nothing_material": [], "_raw": raw_text, "_parse_error": True}
-
-    return digest
+        return TriageDigest(_raw=raw_text, _parse_error=True)
+    except Exception:
+        logger.warning("Failed to validate triage digest, returning raw")
+        return TriageDigest(_raw=raw_text)
 
 
 def store_digest(
     s3_client: boto3.client,
-    digest: dict[str, Any],
+    digest: TriageDigest,
     date_str: str,
     hour: int,
 ) -> str:
@@ -239,7 +246,7 @@ def store_digest(
     payload = {
         "date": date_str,
         "hour": hour,
-        **digest,
+        **digest.model_dump(exclude_none=True, by_alias=True),
     }
     s3_client.put_object(
         Bucket=BUCKET,


### PR DESCRIPTION
## Summary
- Add `models.py` to `src/modules/events/news_scanner/` with Pydantic models: `SerpResult`, `SerpResponse`, `Monitor`, `MaterialItem`, `Significance`, `TriageDigest`, and `NewsScannerConfig`
- Convert `SerpResult`/`SerpResponse` from dataclasses to Pydantic models for consistency
- Replace untyped dicts in `triage.py` (monitors, digest results) and `handler.py` (config, ticker registry) with typed models
- Reuse `TickerRegistry`/`TickerRegistryEntry` from `src/cli/models.py` for ticker registry loading

Partially addresses #5.

## Test plan
- [ ] Verify Lambda handler loads config and ticker registry correctly with new models
- [ ] Verify SERP sweep produces valid `SerpResponse` instances
- [ ] Verify triage digest parsing handles both valid YAML and error/fallback cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)