### PR TITLE
Add Pydantic models to 8k-scanner module

### DIFF
--- a/src/modules/events/eight_k_scanner/analyze/llm.py
+++ b/src/modules/events/eight_k_scanner/analyze/llm.py
@@ -12,6 +12,7 @@ from litellm import completion
 
 from src.modules.events.eight_k_scanner.analyze.prompt import build_messages
 from src.modules.events.eight_k_scanner.config import LLM_MODEL, LLM_TOKENS_PER_MINUTE
+from src.modules.events.eight_k_scanner.models import ExtractedFiling, FinancialSnapshot
 
 logger = logging.getLogger(__name__)
 
@@ -195,8 +196,8 @@ def _call_llm_with_usage(
 
 
 def analyze_filing(
-    extracted: dict,
-    financial_snapshot: dict,
+    extracted: ExtractedFiling,
+    financial_snapshot: FinancialSnapshot,
     ticker: str,
     model: str | None = None,
     messages: list[dict] | None = None,
@@ -211,8 +212,8 @@ def analyze_filing(
 
 
 def analyze_filing_with_usage(
-    extracted: dict,
-    financial_snapshot: dict,
+    extracted: ExtractedFiling,
+    financial_snapshot: FinancialSnapshot,
     ticker: str,
     model: str | None = None,
     messages: list[dict] | None = None,
@@ -225,7 +226,7 @@ def analyze_filing_with_usage(
     if messages is None:
         messages = build_messages(extracted, financial_snapshot, ticker)
 
-    accession = extracted.get("accession_number", "?")
+    accession = extracted.accession_number or "?"
     logger.info(f"Calling LLM screen ({model}) for {ticker} / {accession}")
     screen_content, screen_usage = _call_llm_with_usage(
         model=model,

--- a/src/modules/events/eight_k_scanner/analyze/prompt.py
+++ b/src/modules/events/eight_k_scanner/analyze/prompt.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import logging
 
+from src.modules.events.eight_k_scanner.models import ExtractedFiling, FinancialSnapshot
+
 logger = logging.getLogger(__name__)
 
 MAX_ITEM_CHARS = 20_000
@@ -53,36 +55,34 @@ def _truncate(text: str, max_chars: int, label: str) -> str:
     return text[:max_chars] + "\n\n[TRUNCATED]"
 
 
-def build_messages(extracted: dict, financial_snapshot: dict, ticker: str) -> list[dict]:
+def build_messages(extracted: ExtractedFiling, financial_snapshot: FinancialSnapshot, ticker: str) -> list[dict]:
     """Build the messages list for the LLM call."""
     user_parts = []
 
-    company = extracted.get("ticker", ticker) or ticker
-    accession = extracted.get("accession_number", "")
+    company = extracted.ticker or ticker
+    accession = extracted.accession_number
     user_parts.append(f"## 8-K Filing: {company} ({accession})\n")
 
-    items = extracted.get("items", {})
-    if items:
+    if extracted.items:
         item_text = ""
-        for item_num, text in items.items():
+        for item_num, text in extracted.items.items():
             item_text += f"### Item {item_num}\n{text}\n\n"
         user_parts.append(_truncate(item_text.strip(), MAX_ITEM_CHARS, f"items for {accession}"))
 
-    exhibits = extracted.get("exhibits", [])
-    if exhibits:
+    if extracted.exhibits:
         exhibit_text = ""
-        for ex in exhibits:
-            exhibit_text += f"### Exhibit: {ex['filename']} (type: {ex['type']})\n{ex['text']}\n\n"
+        for ex in extracted.exhibits:
+            exhibit_text += f"### Exhibit: {ex.filename} (type: {ex.type})\n{ex.text}\n\n"
         user_parts.append(_truncate(exhibit_text.strip(), MAX_EXHIBIT_CHARS, f"exhibits for {accession}"))
 
     user_parts.append("## Financial Snapshot")
-    if financial_snapshot and financial_snapshot.get("market_cap") is not None:
-        user_parts.append(f"- Market Cap: {_format_dollars(financial_snapshot.get('market_cap'))}")
-        user_parts.append(f"- Revenue (TTM): {_format_dollars(financial_snapshot.get('revenue_ttm'))}")
-        user_parts.append(f"- Net Income (TTM): {_format_dollars(financial_snapshot.get('net_income_ttm'))}")
-        user_parts.append(f"- Cash: {_format_dollars(financial_snapshot.get('cash'))}")
-        user_parts.append(f"- Total Debt: {_format_dollars(financial_snapshot.get('total_debt'))}")
-        user_parts.append(f"- Source: {financial_snapshot.get('source', 'unknown')}")
+    if financial_snapshot.market_cap is not None:
+        user_parts.append(f"- Market Cap: {_format_dollars(financial_snapshot.market_cap)}")
+        user_parts.append(f"- Revenue (TTM): {_format_dollars(financial_snapshot.revenue_ttm)}")
+        user_parts.append(f"- Net Income (TTM): {_format_dollars(financial_snapshot.net_income_ttm)}")
+        user_parts.append(f"- Cash: {_format_dollars(financial_snapshot.cash)}")
+        user_parts.append(f"- Total Debt: {_format_dollars(financial_snapshot.total_debt)}")
+        user_parts.append(f"- Source: {financial_snapshot.source}")
     else:
         user_parts.append("Financial data unavailable.")
     user_parts.append("")

--- a/src/modules/events/eight_k_scanner/analyzer_handler.py
+++ b/src/modules/events/eight_k_scanner/analyzer_handler.py
@@ -9,6 +9,7 @@ import logging
 
 from src.modules.events.eight_k_scanner.alerts import send_alert
 from src.modules.events.eight_k_scanner.analyze.llm import analyze_filing_with_usage
+from src.modules.events.eight_k_scanner.models import ExtractedFiling
 from src.modules.events.eight_k_scanner.config import (
     S3_BUCKET,
     S3_RAW_PREFIX,
@@ -95,7 +96,7 @@ def _analyze_one(bucket: str, cik: str, accession: str) -> dict:
     # Read extracted data
     extracted_key = f"{prefix}/extracted.json"
     try:
-        extracted = read_json_from_s3(bucket, extracted_key)
+        extracted = ExtractedFiling.model_validate(read_json_from_s3(bucket, extracted_key))
     except Exception:
         logger.error(f"Cannot read extracted.json for {accession}")
         status["action"] = "error"
@@ -103,7 +104,7 @@ def _analyze_one(bucket: str, cik: str, accession: str) -> dict:
         return status
 
     # Item filter
-    items_detected = list(extracted.get("items", {}).keys())
+    items_detected = list(extracted.items.keys())
     passes, matched_items = filter_filing(items_detected, strategy=SCANNER_STRATEGY)
     if not passes:
         warning = f"Items {items_detected or ['?']} don't match strategy={SCANNER_STRATEGY}"

--- a/src/modules/events/eight_k_scanner/ca_analyzer_handler.py
+++ b/src/modules/events/eight_k_scanner/ca_analyzer_handler.py
@@ -5,6 +5,7 @@ import logging
 
 from src.modules.events.eight_k_scanner.alerts import send_alert
 from src.modules.events.eight_k_scanner.analyze.llm import analyze_filing_with_usage
+from src.modules.events.eight_k_scanner.models import ExtractedFiling
 from src.modules.events.eight_k_scanner.config import (
     DISABLE_LLM_ANALYSIS,
     S3_BUCKET,
@@ -94,7 +95,10 @@ def _process_one(bucket: str, ticker: str, release_id: str) -> dict:
         snapshot = get_financial_snapshot(symbol)
         messages = build_pr_messages(release_text, snapshot, symbol)
         try:
-            result = analyze_filing_with_usage({}, snapshot, symbol, messages=messages)
+            result = analyze_filing_with_usage(
+                ExtractedFiling(cik="", accession_number=release_id),
+                snapshot, symbol, messages=messages,
+            )
             analysis_data = result.analysis.model_dump()
             analysis_data["token_usage"] = result.token_usage.model_dump()
             analyzed_at = et_now_iso()

--- a/src/modules/events/eight_k_scanner/ca_handler.py
+++ b/src/modules/events/eight_k_scanner/ca_handler.py
@@ -6,6 +6,7 @@ import logging
 from src.modules.events.eight_k_scanner.canada.poller import poll_canadian_releases
 from src.modules.events.eight_k_scanner.canada.universe import is_in_ca_universe
 from src.modules.events.eight_k_scanner.config import S3_BUCKET, S3_CA_RAW_PREFIX
+from src.modules.events.eight_k_scanner.models import PRIndexMeta
 from src.modules.events.eight_k_scanner.newswire.fetcher import fetch_release
 from src.modules.events.eight_k_scanner.storage.s3 import (
     et_now_iso,
@@ -29,9 +30,9 @@ def lambda_handler(event=None, context=None):
     skipped = 0
 
     for release in releases:
-        ticker = release.get("ticker", "")
-        exchange = release.get("exchange", "")
-        release_id = release["release_id"]
+        ticker = release.ticker
+        exchange = release.exchange
+        release_id = release.release_id
 
         if not ticker:
             filtered_out += 1
@@ -51,30 +52,29 @@ def lambda_handler(event=None, context=None):
             pass
 
         try:
-            result = fetch_release(release["url"], release["source"])
+            result = fetch_release(release.url, release.source)
             extracted_at = et_now_iso()
 
-            meta = {
-                "ticker": ticker,
-                "symbol": info.get("symbol", ""),
-                "exchange": exchange,
-                "market_cap": info.get("market_cap"),
-                "release_id": release_id,
-                "title": release["title"],
-                "url": release["url"],
-                "published_at": release["published_at"],
-                "filed_date": (release.get("published_at", "") or "")[:10],
-                "acceptance_datetime": release.get("published_at", ""),
-                "source": release["source"],
-                "extracted_at": extracted_at,
-                "analyzed_at": None,
-            }
+            meta = PRIndexMeta(
+                ticker=ticker,
+                symbol=info.symbol,
+                exchange=exchange,
+                market_cap=info.market_cap,
+                release_id=release_id,
+                title=release.title,
+                url=release.url,
+                published_at=release.published_at,
+                filed_date=(release.published_at or "")[:10],
+                acceptance_datetime=release.published_at,
+                source=release.source,
+                extracted_at=extracted_at,
+            )
 
-            write_json_to_s3(S3_BUCKET, f"{prefix}/index.json", meta)
+            write_json_to_s3(S3_BUCKET, f"{prefix}/index.json", meta.model_dump())
             get_s3_client().put_object(
                 Bucket=S3_BUCKET,
                 Key=f"{prefix}/release.txt",
-                Body=result["text"],
+                Body=result.text,
                 ContentType="text/plain",
             )
             stored += 1

--- a/src/modules/events/eight_k_scanner/canada/poller.py
+++ b/src/modules/events/eight_k_scanner/canada/poller.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 from botocore.exceptions import ClientError
 
 from src.modules.events.eight_k_scanner.config import S3_BUCKET, CA_LOOKBACK_MINUTES, CA_POLLER_STATE_KEY
+from src.modules.events.eight_k_scanner.models import PressRelease
 from src.modules.events.eight_k_scanner.newswire.cnw import poll_cnw
 from src.modules.events.eight_k_scanner.newswire.dedup import dedup_releases
 from src.modules.events.eight_k_scanner.newswire.gnw import poll_gnw
@@ -21,36 +22,36 @@ GNW_CA_FEEDS = [
 ]
 
 
-def poll_canadian_releases(lookback_minutes: int = CA_LOOKBACK_MINUTES) -> list[dict]:
+def poll_canadian_releases(lookback_minutes: int = CA_LOOKBACK_MINUTES) -> list[PressRelease]:
     last_seen = _load_last_seen()
     min_published_at = datetime.now(timezone.utc) - timedelta(minutes=lookback_minutes)
 
-    all_releases: list[dict] = []
+    all_releases: list[PressRelease] = []
     all_releases.extend(poll_gnw(GNW_CA_FEEDS))
     all_releases.extend(poll_newsfile())
     all_releases.extend(poll_cnw())
 
-    all_releases = [r for r in all_releases if r.get("exchange") in ("TSX", "TSXV")]
+    all_releases = [r for r in all_releases if r.exchange in ("TSX", "TSXV")]
     all_releases = dedup_releases(all_releases)
 
     all_releases = [
         r for r in all_releases
-        if _in_lookback_window(r.get("published_at", ""), min_published_at)
+        if _in_lookback_window(r.published_at, min_published_at)
     ]
     all_releases.sort(
-        key=lambda r: _release_position(r.get("published_at", ""), r.get("release_id", ""))
+        key=lambda r: _release_position(r.published_at, r.release_id)
     )
 
-    new_releases = []
+    new_releases: list[PressRelease] = []
     newest: dict[str, dict[str, str]] = {
         source: _normalize_state_entry(state_entry)
         for source, state_entry in (last_seen or {}).items()
     }
 
     for release in all_releases:
-        source = release["source"]
-        rid = release.get("release_id", "")
-        published_at = release.get("published_at", "")
+        source = release.source
+        rid = release.release_id
+        published_at = release.published_at
         release_pos = _release_position(published_at, rid)
 
         last_entry = newest.get(source, {"published_at": "", "release_id": ""})

--- a/src/modules/events/eight_k_scanner/canada/universe.py
+++ b/src/modules/events/eight_k_scanner/canada/universe.py
@@ -5,6 +5,7 @@ import logging
 
 from src.modules.events.eight_k_scanner.config import CA_MARKET_CAP_THRESHOLD
 from src.modules.events.eight_k_scanner.financials import lookup_market_cap
+from src.modules.events.eight_k_scanner.models import UniverseInfo
 
 logger = logging.getLogger(__name__)
 
@@ -15,16 +16,16 @@ def ca_ticker_symbol(ticker: str, exchange: str) -> str:
     return f"{ticker}.TO"
 
 
-def is_in_ca_universe(ticker: str, exchange: str) -> tuple[bool, dict]:
+def is_in_ca_universe(ticker: str, exchange: str) -> tuple[bool, UniverseInfo]:
     symbol = ca_ticker_symbol(ticker, exchange)
     mcap = lookup_market_cap(symbol)
 
-    info = {
-        "ticker": ticker,
-        "symbol": symbol,
-        "exchange": exchange,
-        "market_cap": mcap,
-    }
+    info = UniverseInfo(
+        ticker=ticker,
+        symbol=symbol,
+        exchange=exchange,
+        market_cap=mcap,
+    )
 
     if mcap is None:
         logger.warning(f"Including {ticker} ({exchange}) despite unknown market cap")

--- a/src/modules/events/eight_k_scanner/edgar/fetcher.py
+++ b/src/modules/events/eight_k_scanner/edgar/fetcher.py
@@ -5,19 +5,15 @@ import logging
 import re
 
 from src.modules.events.eight_k_scanner.edgar.client import edgar_get
+from src.modules.events.eight_k_scanner.models import ExhibitManifestEntry, FilingDocument, FilingMeta
 
 logger = logging.getLogger(__name__)
 
 ARCHIVES_BASE = "https://www.sec.gov/Archives/edgar/data"
 
 
-def fetch_filing(cik: str, accession_number: str) -> dict:
-    """Download a filing's index and all its documents.
-
-    Returns dict with:
-        metadata: filing metadata from the index
-        documents: {filename: bytes_content}
-    """
+def fetch_filing(cik: str, accession_number: str) -> FilingDocument:
+    """Download a filing's index and all its documents."""
     acc_nodashes = accession_number.replace("-", "")
     base_url = f"{ARCHIVES_BASE}/{cik}/{acc_nodashes}"
 
@@ -34,7 +30,7 @@ def fetch_filing(cik: str, accession_number: str) -> dict:
     return _fetch_via_directory(cik, accession_number, base_url)
 
 
-def _fetch_via_json_index(cik: str, accession_number: str, base_url: str, index_data: dict) -> dict:
+def _fetch_via_json_index(cik: str, accession_number: str, base_url: str, index_data: dict) -> FilingDocument:
     directory = index_data.get("directory", {})
     items = directory.get("item", [])
 
@@ -62,7 +58,7 @@ def _fetch_via_json_index(cik: str, accession_number: str, base_url: str, index_
     return _build_result(cik, accession_number, documents, primary_doc)
 
 
-def _fetch_via_directory(cik: str, accession_number: str, base_url: str) -> dict:
+def _fetch_via_directory(cik: str, accession_number: str, base_url: str) -> FilingDocument:
     acc_nodashes = accession_number.replace("-", "")
     dir_url = f"{base_url}/"
     path_prefix = f"/Archives/edgar/data/{cik}/{acc_nodashes}/"
@@ -161,27 +157,27 @@ def _fetch_acceptance_datetime(cik: str, accession_number: str) -> str:
     return ""
 
 
-def _build_result(cik: str, accession_number: str, documents: dict, primary_doc: str | None) -> dict:
+def _build_result(cik: str, accession_number: str, documents: dict, primary_doc: str | None) -> FilingDocument:
     items_detected: list[str] = []
     if primary_doc and primary_doc in documents:
         items_detected = _detect_items(documents[primary_doc])
 
     acceptance_datetime = _fetch_acceptance_datetime(cik, accession_number)
 
-    metadata = {
-        "cik": cik,
-        "accession_number": accession_number,
-        "primary_doc": primary_doc,
-        "items_detected": items_detected,
-        "acceptance_datetime": acceptance_datetime,
-        "exhibit_manifest": [
-            {"filename": name, "type": _classify_exhibit(name)}
+    metadata = FilingMeta(
+        cik=cik,
+        accession_number=accession_number,
+        primary_doc=primary_doc,
+        items_detected=items_detected,
+        acceptance_datetime=acceptance_datetime,
+        exhibit_manifest=[
+            ExhibitManifestEntry(filename=name, type=_classify_exhibit(name))
             for name in documents
             if name != primary_doc
         ],
-    }
+    )
 
-    return {"metadata": metadata, "documents": documents}
+    return FilingDocument(metadata=metadata, documents=documents)
 
 
 def _detect_items(content: bytes | str) -> list[str]:

--- a/src/modules/events/eight_k_scanner/edgar/poller.py
+++ b/src/modules/events/eight_k_scanner/edgar/poller.py
@@ -13,6 +13,7 @@ from src.modules.events.eight_k_scanner.config import (
     SCANNER_POLLER_SEEN_TTL_DAYS,
 )
 from src.modules.events.eight_k_scanner.edgar.client import edgar_get
+from src.modules.events.eight_k_scanner.models import PolledFiling
 from src.modules.events.eight_k_scanner.storage.s3 import read_json_from_s3, write_json_to_s3
 
 logger = logging.getLogger(__name__)
@@ -20,8 +21,8 @@ logger = logging.getLogger(__name__)
 EFTS_URL = "https://efts.sec.gov/LATEST/search-index"
 
 
-def poll_new_8k_filings(lookback_minutes: int = 60) -> list[dict]:
-    """Discover new 8-K filings via EFTS. Returns list of filing metadata dicts."""
+def poll_new_8k_filings(lookback_minutes: int = 60) -> list[PolledFiling]:
+    """Discover new 8-K filings via EFTS. Returns list of PolledFiling."""
     now_utc = datetime.now(timezone.utc)
     start_dt = now_utc - timedelta(minutes=lookback_minutes)
     fetch_start = start_dt.date()
@@ -35,9 +36,9 @@ def poll_new_8k_filings(lookback_minutes: int = 60) -> list[dict]:
         logger.info("EFTS returned no results, falling back to RSS")
         filings = _fetch_rss()
 
-    new_filings = []
+    new_filings: list[PolledFiling] = []
     for filing in filings:
-        accession = filing.get("accession_number", "")
+        accession = filing.accession_number
         if not accession:
             continue
         if accession in seen_accessions:
@@ -52,7 +53,7 @@ def poll_new_8k_filings(lookback_minutes: int = 60) -> list[dict]:
         {
             "seen_accessions": _prune_and_stamp_seen_accessions(
                 state.get("seen_accessions", {}),
-                new_accessions=[f["accession_number"] for f in new_filings],
+                new_accessions=[f.accession_number for f in new_filings],
                 now_utc=now_utc,
                 ttl_days=SCANNER_POLLER_SEEN_TTL_DAYS,
             ),
@@ -64,18 +65,18 @@ def poll_new_8k_filings(lookback_minutes: int = 60) -> list[dict]:
     return new_filings
 
 
-def _in_lookback_window(filing: Dict[str, str], start_dt: datetime, end_dt: datetime) -> bool:
+def _in_lookback_window(filing: PolledFiling, start_dt: datetime, end_dt: datetime) -> bool:
     filing_dt = _parse_filing_datetime(filing)
     if filing_dt is None:
-        filed_date = (filing.get("filed_date") or "")[:10]
+        filed_date = (filing.filed_date or "")[:10]
         if not filed_date:
             return True
         return start_dt.date().isoformat() <= filed_date <= end_dt.date().isoformat()
     return start_dt <= filing_dt <= end_dt
 
 
-def _parse_filing_datetime(filing: Dict[str, str]) -> datetime | None:
-    raw_acceptance = (filing.get("acceptance_datetime") or "").strip()
+def _parse_filing_datetime(filing: PolledFiling) -> datetime | None:
+    raw_acceptance = (filing.acceptance_datetime or "").strip()
     if raw_acceptance and "T" in raw_acceptance:
         parsed = _parse_datetime(raw_acceptance)
         if parsed is not None:
@@ -126,7 +127,7 @@ def _prune_and_stamp_seen_accessions(
     return keep
 
 
-def fetch_filings_by_date(start_date: date, end_date: date) -> list[dict]:
+def fetch_filings_by_date(start_date: date, end_date: date) -> list[PolledFiling]:
     """Fetch all 8-K filings in a date range (no state-based dedupe)."""
     filings = _fetch_efts(start_date, end_date)
     if not filings:
@@ -136,8 +137,8 @@ def fetch_filings_by_date(start_date: date, end_date: date) -> list[dict]:
     return filings
 
 
-def _fetch_efts(start_date: date, end_date: date) -> list[dict]:
-    all_filings: list[dict] = []
+def _fetch_efts(start_date: date, end_date: date) -> list[PolledFiling]:
+    all_filings: list[PolledFiling] = []
     page_from = 0
     page_size = 100
 
@@ -166,8 +167,8 @@ def _fetch_efts(start_date: date, end_date: date) -> list[dict]:
     return all_filings
 
 
-def _parse_efts_response(data: dict) -> list[dict]:
-    filings = []
+def _parse_efts_response(data: dict) -> list[PolledFiling]:
+    filings: list[PolledFiling] = []
     hits = data.get("hits", {}).get("hits", [])
     for hit in hits:
         src = hit.get("_source", {})
@@ -195,21 +196,21 @@ def _parse_efts_response(data: dict) -> list[dict]:
                     ticker = token
                     break
 
-        filings.append({
-            "cik": cik,
-            "accession_number": accession,
-            "company_name": company_name,
-            "ticker": ticker,
-            "filed_date": src.get("file_date", ""),
-            "acceptance_datetime": src.get("file_date", ""),
-            "items": src.get("items", []),
-        })
+        filings.append(PolledFiling(
+            cik=cik,
+            accession_number=accession,
+            company_name=company_name,
+            ticker=ticker,
+            filed_date=src.get("file_date", ""),
+            acceptance_datetime=src.get("file_date", ""),
+            items=src.get("items", []),
+        ))
 
     logger.info(f"EFTS returned {len(filings)} 8-K filings (from {len(hits)} hits)")
     return filings
 
 
-def _fetch_rss() -> list[dict]:
+def _fetch_rss() -> list[PolledFiling]:
     url = (
         "https://www.sec.gov/cgi-bin/browse-edgar"
         "?action=getcurrent&type=8-K&count=100&output=atom"
@@ -222,10 +223,10 @@ def _fetch_rss() -> list[dict]:
         return []
 
 
-def _parse_rss(xml_text: str) -> list[dict]:
+def _parse_rss(xml_text: str) -> list[PolledFiling]:
     import xml.etree.ElementTree as ET
 
-    filings = []
+    filings: list[PolledFiling] = []
     root = ET.fromstring(xml_text)
     ns = {"atom": "http://www.w3.org/2005/Atom"}
 
@@ -250,13 +251,13 @@ def _parse_rss(xml_text: str) -> list[dict]:
         if cik and accession:
             if "-" not in accession and len(accession) >= 10:
                 accession = f"{accession[:10]}-{accession[10:12]}-{accession[12:]}"
-            filings.append({
-                "cik": cik,
-                "accession_number": accession,
-                "company_name": title.replace("8-K", "").strip(" -"),
-                "filed_date": updated[:10] if updated else "",
-                "acceptance_datetime": updated,
-            })
+            filings.append(PolledFiling(
+                cik=cik,
+                accession_number=accession,
+                company_name=title.replace("8-K", "").strip(" -"),
+                filed_date=updated[:10] if updated else "",
+                acceptance_datetime=updated,
+            ))
 
     return filings
 

--- a/src/modules/events/eight_k_scanner/extract/parser.py
+++ b/src/modules/events/eight_k_scanner/extract/parser.py
@@ -7,6 +7,7 @@ import re
 from bs4 import BeautifulSoup
 
 from src.modules.events.eight_k_scanner.config import S3_BUCKET, S3_RAW_PREFIX
+from src.modules.events.eight_k_scanner.models import ExtractedExhibit, ExtractedFiling
 from src.modules.events.eight_k_scanner.storage.s3 import get_s3_client, read_json_from_s3, write_json_to_s3
 
 logger = logging.getLogger(__name__)
@@ -61,10 +62,10 @@ def _should_skip_file(filename: str) -> bool:
     return False
 
 
-def extract_filing(cik: str, accession_number: str, bucket: str | None = None, force: bool = False) -> dict | None:
+def extract_filing(cik: str, accession_number: str, bucket: str | None = None, force: bool = False) -> ExtractedFiling | None:
     """Extract text from a raw filing in S3. Writes extracted.json back to S3.
 
-    Returns the extracted data dict, or None if already extracted and not force.
+    Returns the ExtractedFiling, or None if already extracted and not force.
     """
     bucket = bucket or S3_BUCKET
     prefix = f"{S3_RAW_PREFIX}/{cik}/{accession_number}"
@@ -109,7 +110,7 @@ def extract_filing(cik: str, accession_number: str, bucket: str | None = None, f
     else:
         logger.warning(f"No primary doc for {accession_number}")
 
-    exhibits: list[dict] = []
+    exhibits: list[ExtractedExhibit] = []
     for exhibit in exhibit_manifest:
         filename = exhibit.get("filename", "")
         exhibit_type = exhibit.get("type", "other")
@@ -130,11 +131,11 @@ def extract_filing(cik: str, accession_number: str, bucket: str | None = None, f
             text = _parse_html(content)
             text = _strip_exhibit_boilerplate(text)
             if text.strip():
-                exhibits.append({
-                    "filename": filename,
-                    "type": exhibit_type,
-                    "text": text.strip(),
-                })
+                exhibits.append(ExtractedExhibit(
+                    filename=filename,
+                    type=exhibit_type,
+                    text=text.strip(),
+                ))
                 files_processed += 1
             else:
                 files_skipped += 1
@@ -142,20 +143,20 @@ def extract_filing(cik: str, accession_number: str, bucket: str | None = None, f
             logger.warning(f"Failed to parse exhibit {filename}: {e}")
             files_skipped += 1
 
-    total_chars = sum(len(v) for v in items.values()) + sum(len(e["text"]) for e in exhibits)
+    total_chars = sum(len(v) for v in items.values()) + sum(len(e.text) for e in exhibits)
 
-    result = {
-        "cik": cik,
-        "accession_number": accession_number,
-        "ticker": ticker,
-        "items": items,
-        "exhibits": exhibits,
-        "total_chars": total_chars,
-        "files_processed": files_processed,
-        "files_skipped": files_skipped,
-    }
+    result = ExtractedFiling(
+        cik=cik,
+        accession_number=accession_number,
+        ticker=ticker,
+        items=items,
+        exhibits=exhibits,
+        total_chars=total_chars,
+        files_processed=files_processed,
+        files_skipped=files_skipped,
+    )
 
-    write_json_to_s3(bucket, output_key, result)
+    write_json_to_s3(bucket, output_key, result.model_dump())
     logger.info(f"Extracted {accession_number}: {files_processed} files, {total_chars} chars")
     return result
 

--- a/src/modules/events/eight_k_scanner/extractor_handler.py
+++ b/src/modules/events/eight_k_scanner/extractor_handler.py
@@ -59,8 +59,8 @@ def _extract_one(bucket: str, cik: str, accession: str) -> dict:
             status["action"] = "already_extracted"
         else:
             status["action"] = "extracted"
-            status["total_chars"] = extracted.get("total_chars", 0)
-            status["items"] = list(extracted.get("items", {}).keys())
+            status["total_chars"] = extracted.total_chars
+            status["items"] = list(extracted.items.keys())
     except Exception:
         logger.exception(f"Extraction failed for {cik}/{accession}")
         status["action"] = "error"

--- a/src/modules/events/eight_k_scanner/financials.py
+++ b/src/modules/events/eight_k_scanner/financials.py
@@ -7,6 +7,7 @@ import requests
 import yfinance as yf
 
 from src.modules.events.eight_k_scanner.config import FMP_API_KEY, EODHD_API_KEY
+from src.modules.events.eight_k_scanner.models import FinancialSnapshot
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +43,7 @@ def lookup_market_cap(ticker: str) -> int | None:
     return None
 
 
-def get_financial_snapshot(ticker: str) -> dict:
+def get_financial_snapshot(ticker: str) -> FinancialSnapshot:
     """Full financial snapshot for LLM context."""
     snap = _fmp_snapshot(ticker)
     if snap:
@@ -73,7 +74,7 @@ def _fmp_market_cap(ticker: str) -> int | None:
     return None
 
 
-def _fmp_snapshot(ticker: str) -> dict | None:
+def _fmp_snapshot(ticker: str) -> FinancialSnapshot | None:
     if not FMP_API_KEY:
         return None
     try:
@@ -95,14 +96,7 @@ def _fmp_snapshot(ticker: str) -> dict | None:
         if not market_cap:
             return None
 
-        snap = {
-            "market_cap": market_cap,
-            "revenue_ttm": None,
-            "net_income_ttm": None,
-            "cash": None,
-            "total_debt": None,
-            "source": "fmp",
-        }
+        snap = FinancialSnapshot(market_cap=market_cap, source="fmp")
 
         try:
             is_resp = requests.get(
@@ -113,8 +107,8 @@ def _fmp_snapshot(ticker: str) -> dict | None:
             is_resp.raise_for_status()
             is_data = is_resp.json()
             if isinstance(is_data, list) and is_data:
-                snap["revenue_ttm"] = is_data[0].get("revenue")
-                snap["net_income_ttm"] = is_data[0].get("netIncome")
+                snap.revenue_ttm = is_data[0].get("revenue")
+                snap.net_income_ttm = is_data[0].get("netIncome")
         except Exception:
             pass
 
@@ -127,8 +121,8 @@ def _fmp_snapshot(ticker: str) -> dict | None:
             bs_resp.raise_for_status()
             bs_data = bs_resp.json()
             if isinstance(bs_data, list) and bs_data:
-                snap["cash"] = bs_data[0].get("cashAndCashEquivalents")
-                snap["total_debt"] = bs_data[0].get("totalDebt")
+                snap.cash = bs_data[0].get("cashAndCashEquivalents")
+                snap.total_debt = bs_data[0].get("totalDebt")
         except Exception:
             pass
 
@@ -156,7 +150,7 @@ def _eodhd_market_cap(ticker: str) -> int | None:
     return None
 
 
-def _eodhd_snapshot(ticker: str) -> dict | None:
+def _eodhd_snapshot(ticker: str) -> FinancialSnapshot | None:
     if not EODHD_API_KEY:
         return None
     try:
@@ -173,18 +167,11 @@ def _eodhd_snapshot(ticker: str) -> dict | None:
         if not market_cap:
             return None
 
-        snap = {
-            "market_cap": int(market_cap),
-            "revenue_ttm": None,
-            "net_income_ttm": None,
-            "cash": None,
-            "total_debt": None,
-            "source": "eodhd",
-        }
+        snap = FinancialSnapshot(market_cap=int(market_cap), source="eodhd")
 
         revenue = highlights.get("RevenueTTM")
         if revenue:
-            snap["revenue_ttm"] = int(float(revenue))
+            snap.revenue_ttm = int(float(revenue))
 
         financials = data.get("Financials", {})
         income_stmt = financials.get("Income_Statement", {}).get("quarterly", {})
@@ -192,17 +179,17 @@ def _eodhd_snapshot(ticker: str) -> dict | None:
             latest = next(iter(income_stmt.values()), {})
             ni = latest.get("netIncome")
             if ni:
-                snap["net_income_ttm"] = int(float(ni))
+                snap.net_income_ttm = int(float(ni))
 
         balance_sheet = financials.get("Balance_Sheet", {}).get("quarterly", {})
         if balance_sheet:
             latest_bs = next(iter(balance_sheet.values()), {})
             cash = latest_bs.get("cashAndShortTermInvestments") or latest_bs.get("cash")
             if cash:
-                snap["cash"] = int(float(cash))
+                snap.cash = int(float(cash))
             debt = latest_bs.get("shortLongTermDebtTotal") or latest_bs.get("longTermDebt")
             if debt:
-                snap["total_debt"] = int(float(debt))
+                snap.total_debt = int(float(debt))
 
         return snap
     except Exception:
@@ -343,23 +330,16 @@ def _eodhd_adtv(ticker: str) -> float | None:
         return None
 
 
-def _yfinance_snapshot(ticker: str) -> dict:
-    snap = {
-        "market_cap": None,
-        "revenue_ttm": None,
-        "net_income_ttm": None,
-        "cash": None,
-        "total_debt": None,
-        "source": "yfinance",
-    }
+def _yfinance_snapshot(ticker: str) -> FinancialSnapshot:
+    snap = FinancialSnapshot(source="yfinance")
     try:
         t = yf.Ticker(ticker)
         info = t.info
-        snap["market_cap"] = info.get("marketCap")
-        snap["revenue_ttm"] = info.get("totalRevenue")
-        snap["net_income_ttm"] = info.get("netIncomeToCommon")
-        snap["cash"] = info.get("totalCash")
-        snap["total_debt"] = info.get("totalDebt")
+        snap.market_cap = info.get("marketCap")
+        snap.revenue_ttm = info.get("totalRevenue")
+        snap.net_income_ttm = info.get("netIncomeToCommon")
+        snap.cash = info.get("totalCash")
+        snap.total_debt = info.get("totalDebt")
     except Exception:
         pass
     return snap

--- a/src/modules/events/eight_k_scanner/models.py
+++ b/src/modules/events/eight_k_scanner/models.py
@@ -1,0 +1,168 @@
+"""Pydantic models for the 8-K scanner module.
+
+Replaces untyped dicts flowing between poller, fetcher, extractor, analyzer,
+and alerting subsystems.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# EDGAR poller / filing metadata
+# ---------------------------------------------------------------------------
+
+
+class ExhibitManifestEntry(BaseModel):
+    filename: str
+    type: str = "other"
+
+
+class FilingMeta(BaseModel):
+    """Metadata stored as index.json in S3 for an 8-K filing."""
+
+    cik: str
+    accession_number: str
+    primary_doc: str | None = None
+    items_detected: list[str] = Field(default_factory=list)
+    acceptance_datetime: str = ""
+    exhibit_manifest: list[ExhibitManifestEntry] = Field(default_factory=list)
+
+    # Enriched by poller_handler after universe check
+    ticker: str = ""
+    company_name: str = ""
+    market_cap: int | None = None
+    exchange: str = ""
+    filed_date: str = ""
+    source: str = ""
+
+    # Timestamps set during processing
+    extracted_at: str | None = None
+    analyzed_at: str | None = None
+    alert_sent_at: str | None = None
+
+
+class FilingDocument(BaseModel):
+    """Result of fetching a filing's raw documents from EDGAR."""
+
+    metadata: FilingMeta
+    documents: dict[str, bytes] = Field(default_factory=dict)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+# ---------------------------------------------------------------------------
+# Poller output (what EFTS / RSS returns before enrichment)
+# ---------------------------------------------------------------------------
+
+
+class PolledFiling(BaseModel):
+    """A filing discovered by the EDGAR poller (EFTS or RSS)."""
+
+    cik: str
+    accession_number: str
+    company_name: str = ""
+    ticker: str = ""
+    filed_date: str = ""
+    acceptance_datetime: str = ""
+    items: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+
+class ExtractedExhibit(BaseModel):
+    filename: str
+    type: str = "other"
+    text: str
+
+
+class ExtractedFiling(BaseModel):
+    """Output of the HTML parser / item splitter (extracted.json)."""
+
+    cik: str
+    accession_number: str
+    ticker: str = ""
+    items: dict[str, str] = Field(default_factory=dict)
+    exhibits: list[ExtractedExhibit] = Field(default_factory=list)
+    total_chars: int = 0
+    files_processed: int = 0
+    files_skipped: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Financial snapshot
+# ---------------------------------------------------------------------------
+
+
+class FinancialSnapshot(BaseModel):
+    market_cap: int | None = None
+    revenue_ttm: int | None = None
+    net_income_ttm: int | None = None
+    cash: int | None = None
+    total_debt: int | None = None
+    source: str = "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Universe info
+# ---------------------------------------------------------------------------
+
+
+class UniverseInfo(BaseModel):
+    ticker: str = ""
+    company_name: str = ""
+    market_cap: int | None = None
+    exchange: str = ""
+    symbol: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Newswire / press release
+# ---------------------------------------------------------------------------
+
+
+class PressRelease(BaseModel):
+    """A press release discovered from a newswire feed."""
+
+    release_id: str
+    title: str = ""
+    url: str = ""
+    published_at: str = ""
+    source: str = ""
+    ticker: str = ""
+    exchange: str = ""
+
+
+class FetchedRelease(BaseModel):
+    """Result of fetching full press release text."""
+
+    text: str
+    metadata: dict[str, str] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Press release index (stored as index.json for CA / US PR)
+# ---------------------------------------------------------------------------
+
+
+class PRIndexMeta(BaseModel):
+    """Metadata stored as index.json for a press release in S3."""
+
+    ticker: str
+    symbol: str = ""
+    exchange: str = ""
+    market_cap: int | None = None
+    release_id: str
+    title: str = ""
+    url: str = ""
+    published_at: str = ""
+    filed_date: str = ""
+    acceptance_datetime: str = ""
+    source: str = ""
+    extracted_at: str | None = None
+    analyzed_at: str | None = None
+    alert_sent_at: str | None = None

--- a/src/modules/events/eight_k_scanner/newswire/cnw.py
+++ b/src/modules/events/eight_k_scanner/newswire/cnw.py
@@ -7,6 +7,8 @@ import re
 import requests
 from bs4 import BeautifulSoup
 
+from src.modules.events.eight_k_scanner.models import PressRelease
+
 logger = logging.getLogger(__name__)
 
 USER_AGENT = "PraxisCopilot/1.0"
@@ -18,8 +20,8 @@ TICKER_RE = re.compile(
 )
 
 
-def poll_cnw(pages: int = 2) -> list[dict]:
-    releases = []
+def poll_cnw(pages: int = 2) -> list[PressRelease]:
+    releases: list[PressRelease] = []
     for page in range(1, pages + 1):
         url = CNW_LISTING_URL if page == 1 else f"{CNW_LISTING_URL}?page={page}"
         try:
@@ -32,9 +34,9 @@ def poll_cnw(pages: int = 2) -> list[dict]:
     return releases
 
 
-def _parse_listing(html: str) -> list[dict]:
+def _parse_listing(html: str) -> list[PressRelease]:
     soup = BeautifulSoup(html, "lxml")
-    items = []
+    items: list[PressRelease] = []
 
     for card in soup.select("div.card, article.news-release, div.news-release"):
         link_el = card.find("a", href=True)
@@ -57,15 +59,15 @@ def _parse_listing(html: str) -> list[dict]:
 
         ticker, exchange = _extract_ticker(title)
 
-        items.append({
-            "release_id": f"cnw-{release_id}",
-            "title": title,
-            "url": href,
-            "published_at": published_at,
-            "source": "cnw",
-            "ticker": ticker,
-            "exchange": exchange,
-        })
+        items.append(PressRelease(
+            release_id=f"cnw-{release_id}",
+            title=title,
+            url=href,
+            published_at=published_at,
+            source="cnw",
+            ticker=ticker,
+            exchange=exchange,
+        ))
 
     return items
 

--- a/src/modules/events/eight_k_scanner/newswire/dedup.py
+++ b/src/modules/events/eight_k_scanner/newswire/dedup.py
@@ -4,22 +4,24 @@ from __future__ import annotations
 import logging
 from difflib import SequenceMatcher
 
+from src.modules.events.eight_k_scanner.models import PressRelease
+
 logger = logging.getLogger(__name__)
 
 SIMILARITY_THRESHOLD = 0.75
 
 
-def dedup_releases(releases: list[dict]) -> list[dict]:
+def dedup_releases(releases: list[PressRelease]) -> list[PressRelease]:
     """Remove duplicate releases across sources (same ticker + similar title)."""
     if not releases:
         return []
 
     seen: list[tuple[str, str]] = []
-    result = []
+    result: list[PressRelease] = []
 
     for release in releases:
-        ticker = release.get("ticker", "")
-        title = release.get("title", "")
+        ticker = release.ticker
+        title = release.title
 
         if not ticker:
             result.append(release)

--- a/src/modules/events/eight_k_scanner/newswire/fetcher.py
+++ b/src/modules/events/eight_k_scanner/newswire/fetcher.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 
+from src.modules.events.eight_k_scanner.models import FetchedRelease
 from src.modules.events.eight_k_scanner.newswire.gnw import fetch_gnw_text
 from src.modules.events.eight_k_scanner.newswire.newsfile import fetch_newsfile_text
 from src.modules.events.eight_k_scanner.newswire.cnw import fetch_cnw_text
@@ -16,10 +17,10 @@ _FETCHERS = {
 }
 
 
-def fetch_release(url: str, source: str) -> dict:
-    """Fetch full press release text. Returns {"text": str, "metadata": dict}."""
+def fetch_release(url: str, source: str) -> FetchedRelease:
+    """Fetch full press release text."""
     fetcher = _FETCHERS.get(source)
     if not fetcher:
         raise ValueError(f"Unknown newswire source: {source}")
     text = fetcher(url)
-    return {"text": text, "metadata": {"url": url, "source": source}}
+    return FetchedRelease(text=text, metadata={"url": url, "source": source})

--- a/src/modules/events/eight_k_scanner/newswire/gnw.py
+++ b/src/modules/events/eight_k_scanner/newswire/gnw.py
@@ -9,6 +9,8 @@ from email.utils import parsedate_to_datetime
 import requests
 from bs4 import BeautifulSoup
 
+from src.modules.events.eight_k_scanner.models import PressRelease
+
 logger = logging.getLogger(__name__)
 
 USER_AGENT = "PraxisCopilot/1.0"
@@ -18,8 +20,8 @@ TICKER_RE = re.compile(
 )
 
 
-def poll_gnw(feed_urls: list[str]) -> list[dict]:
-    releases = []
+def poll_gnw(feed_urls: list[str]) -> list[PressRelease]:
+    releases: list[PressRelease] = []
     for url in feed_urls:
         try:
             resp = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=15)
@@ -31,8 +33,8 @@ def poll_gnw(feed_urls: list[str]) -> list[dict]:
     return releases
 
 
-def _parse_rss(xml_text: str) -> list[dict]:
-    items = []
+def _parse_rss(xml_text: str) -> list[PressRelease]:
+    items: list[PressRelease] = []
     root = ET.fromstring(xml_text)
     for item in root.iter("item"):
         title = item.findtext("title", "")
@@ -54,15 +56,15 @@ def _parse_rss(xml_text: str) -> list[dict]:
             except Exception:
                 published_at = pub_date
 
-        items.append({
-            "release_id": f"gnw-{release_id}",
-            "title": title,
-            "url": link,
-            "published_at": published_at,
-            "source": "gnw",
-            "ticker": ticker,
-            "exchange": exchange,
-        })
+        items.append(PressRelease(
+            release_id=f"gnw-{release_id}",
+            title=title,
+            url=link,
+            published_at=published_at,
+            source="gnw",
+            ticker=ticker,
+            exchange=exchange,
+        ))
     return items
 
 

--- a/src/modules/events/eight_k_scanner/newswire/newsfile.py
+++ b/src/modules/events/eight_k_scanner/newswire/newsfile.py
@@ -10,6 +10,8 @@ from email.utils import parsedate_to_datetime
 import requests
 from bs4 import BeautifulSoup
 
+from src.modules.events.eight_k_scanner.models import PressRelease
+
 logger = logging.getLogger(__name__)
 
 USER_AGENT = "PraxisCopilot/1.0"
@@ -28,9 +30,9 @@ TICKER_RE = re.compile(
 )
 
 
-def poll_newsfile(categories: list[str] | None = None) -> list[dict]:
+def poll_newsfile(categories: list[str] | None = None) -> list[PressRelease]:
     categories = categories or DEFAULT_CATEGORIES
-    releases = []
+    releases: list[PressRelease] = []
     for cat in categories:
         url = f"https://feeds.newsfilecorp.com/industry/{cat}"
         try:
@@ -45,8 +47,8 @@ def poll_newsfile(categories: list[str] | None = None) -> list[dict]:
     return releases
 
 
-def _parse_rss(xml_text: str) -> list[dict]:
-    items = []
+def _parse_rss(xml_text: str) -> list[PressRelease]:
+    items: list[PressRelease] = []
     root = ET.fromstring(xml_text)
     for item in root.iter("item"):
         title = item.findtext("title", "")
@@ -68,15 +70,15 @@ def _parse_rss(xml_text: str) -> list[dict]:
             except Exception:
                 published_at = pub_date
 
-        items.append({
-            "release_id": f"newsfile-{release_id}",
-            "title": title,
-            "url": link,
-            "published_at": published_at,
-            "source": "newsfile",
-            "ticker": ticker,
-            "exchange": exchange,
-        })
+        items.append(PressRelease(
+            release_id=f"newsfile-{release_id}",
+            title=title,
+            url=link,
+            published_at=published_at,
+            source="newsfile",
+            ticker=ticker,
+            exchange=exchange,
+        ))
     return items
 
 

--- a/src/modules/events/eight_k_scanner/newswire/prompt.py
+++ b/src/modules/events/eight_k_scanner/newswire/prompt.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import logging
 
+from src.modules.events.eight_k_scanner.models import FinancialSnapshot
+
 logger = logging.getLogger(__name__)
 
 MAX_RELEASE_CHARS = 40_000
@@ -52,7 +54,7 @@ def _truncate(text: str, max_chars: int, label: str) -> str:
     return text[:max_chars] + "\n\n[TRUNCATED]"
 
 
-def build_pr_messages(release_text: str, financial_snapshot: dict, ticker: str) -> list[dict]:
+def build_pr_messages(release_text: str, financial_snapshot: FinancialSnapshot, ticker: str) -> list[dict]:
     """Build LLM messages for press release analysis."""
     user_parts = []
 
@@ -61,13 +63,13 @@ def build_pr_messages(release_text: str, financial_snapshot: dict, ticker: str) 
     user_parts.append("")
 
     user_parts.append("## Financial Snapshot")
-    if financial_snapshot and financial_snapshot.get("market_cap") is not None:
-        user_parts.append(f"- Market Cap: {_format_dollars(financial_snapshot.get('market_cap'))}")
-        user_parts.append(f"- Revenue (TTM): {_format_dollars(financial_snapshot.get('revenue_ttm'))}")
-        user_parts.append(f"- Net Income (TTM): {_format_dollars(financial_snapshot.get('net_income_ttm'))}")
-        user_parts.append(f"- Cash: {_format_dollars(financial_snapshot.get('cash'))}")
-        user_parts.append(f"- Total Debt: {_format_dollars(financial_snapshot.get('total_debt'))}")
-        user_parts.append(f"- Source: {financial_snapshot.get('source', 'unknown')}")
+    if financial_snapshot.market_cap is not None:
+        user_parts.append(f"- Market Cap: {_format_dollars(financial_snapshot.market_cap)}")
+        user_parts.append(f"- Revenue (TTM): {_format_dollars(financial_snapshot.revenue_ttm)}")
+        user_parts.append(f"- Net Income (TTM): {_format_dollars(financial_snapshot.net_income_ttm)}")
+        user_parts.append(f"- Cash: {_format_dollars(financial_snapshot.cash)}")
+        user_parts.append(f"- Total Debt: {_format_dollars(financial_snapshot.total_debt)}")
+        user_parts.append(f"- Source: {financial_snapshot.source}")
     else:
         user_parts.append("Financial data unavailable.")
     user_parts.append("")

--- a/src/modules/events/eight_k_scanner/poller_handler.py
+++ b/src/modules/events/eight_k_scanner/poller_handler.py
@@ -29,8 +29,8 @@ def lambda_handler(event=None, context=None):
     filtered_out = 0
 
     for filing_meta in filings:
-        cik = filing_meta["cik"]
-        accession = filing_meta["accession_number"]
+        cik = filing_meta.cik
+        accession = filing_meta.accession_number
 
         in_universe, info = is_in_universe(cik)
         if not in_universe:
@@ -44,18 +44,16 @@ def lambda_handler(event=None, context=None):
         try:
             result = fetch_filing(cik, accession)
 
-            meta = result["metadata"]
-            meta["ticker"] = info.get("ticker", "")
-            meta["company_name"] = info.get("company_name") or filing_meta.get("company_name", "")
-            meta["market_cap"] = info.get("market_cap")
-            meta["exchange"] = info.get("exchange", "")
-            meta["filed_date"] = filing_meta.get("filed_date", "")
-            if not meta.get("acceptance_datetime"):
-                meta["acceptance_datetime"] = filing_meta.get("acceptance_datetime", "")
-            else:
-                meta["acceptance_datetime"] = meta["acceptance_datetime"] or filing_meta.get("acceptance_datetime", "")
+            meta = result.metadata
+            meta.ticker = info.ticker
+            meta.company_name = info.company_name or filing_meta.company_name
+            meta.market_cap = info.market_cap
+            meta.exchange = info.exchange
+            meta.filed_date = filing_meta.filed_date
+            if not meta.acceptance_datetime:
+                meta.acceptance_datetime = filing_meta.acceptance_datetime
 
-            store_filing(cik, accession, meta, result["documents"])
+            store_filing(cik, accession, meta.model_dump(), result.documents)
             stored += 1
 
         except Exception:

--- a/src/modules/events/eight_k_scanner/universe/builder.py
+++ b/src/modules/events/eight_k_scanner/universe/builder.py
@@ -12,6 +12,7 @@ from src.modules.events.eight_k_scanner.config import (
     get_ticker_registry,
 )
 from src.modules.events.eight_k_scanner.financials import lookup_market_cap
+from src.modules.events.eight_k_scanner.models import UniverseInfo
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +58,7 @@ def _build_registry_cik_map() -> dict[str, dict]:
     return cik_map
 
 
-def is_in_universe(cik: str) -> tuple[bool, dict]:
+def is_in_universe(cik: str) -> tuple[bool, UniverseInfo]:
     """Check if a CIK belongs to our universe.
 
     First checks the ticker registry from S3 config. Falls back to SEC ticker map
@@ -68,40 +69,40 @@ def is_in_universe(cik: str) -> tuple[bool, dict]:
     # Check ticker registry first (all registered tickers are in-universe)
     registry_map = _build_registry_cik_map()
     if cik in registry_map:
-        info = registry_map[cik]
-        ticker = info["ticker"]
+        reg = registry_map[cik]
+        ticker = reg["ticker"]
         mcap = lookup_market_cap(ticker)
-        return True, {
-            "ticker": ticker,
-            "company_name": info["company_name"],
-            "market_cap": mcap,
-            "exchange": info.get("exchange", ""),
-        }
+        return True, UniverseInfo(
+            ticker=ticker,
+            company_name=reg["company_name"],
+            market_cap=mcap,
+            exchange=reg.get("exchange", ""),
+        )
 
     # Fall back to SEC ticker map + market cap filter
     cik_map = get_cik_map()
     info = cik_map.get(cik)
     if not info:
-        return False, {}
+        return False, UniverseInfo()
 
     ticker = info["ticker"]
 
     if _is_non_common(ticker):
-        return False, {}
+        return False, UniverseInfo()
 
     if ticker.upper() in [t.upper() for t in WATCHLIST_TICKERS]:
         mcap = lookup_market_cap(ticker)
-        return True, {"ticker": ticker, "company_name": info["company_name"], "market_cap": mcap}
+        return True, UniverseInfo(ticker=ticker, company_name=info["company_name"], market_cap=mcap)
 
     mcap = lookup_market_cap(ticker)
     if mcap is None:
         logger.warning(f"Including {ticker} (CIK {cik}) despite unknown market cap")
-        return True, {"ticker": ticker, "company_name": info["company_name"], "market_cap": None}
+        return True, UniverseInfo(ticker=ticker, company_name=info["company_name"], market_cap=None)
 
     if mcap <= MARKET_CAP_THRESHOLD:
-        return True, {"ticker": ticker, "company_name": info["company_name"], "market_cap": mcap}
+        return True, UniverseInfo(ticker=ticker, company_name=info["company_name"], market_cap=mcap)
 
-    return False, {"ticker": ticker, "company_name": info["company_name"], "market_cap": mcap}
+    return False, UniverseInfo(ticker=ticker, company_name=info["company_name"], market_cap=mcap)
 
 
 def _fetch_sec_ticker_map() -> dict:

--- a/src/modules/events/eight_k_scanner/us_gnw_analyzer_handler.py
+++ b/src/modules/events/eight_k_scanner/us_gnw_analyzer_handler.py
@@ -5,6 +5,7 @@ import logging
 
 from src.modules.events.eight_k_scanner.alerts import send_alert
 from src.modules.events.eight_k_scanner.analyze.llm import analyze_filing_with_usage
+from src.modules.events.eight_k_scanner.models import ExtractedFiling
 from src.modules.events.eight_k_scanner.config import (
     DISABLE_LLM_ANALYSIS,
     S3_BUCKET,
@@ -93,7 +94,10 @@ def _process_one(bucket: str, ticker: str, release_id: str) -> dict:
         snapshot = get_financial_snapshot(ticker)
         messages = build_pr_messages(release_text, snapshot, ticker)
         try:
-            result = analyze_filing_with_usage({}, snapshot, ticker, messages=messages)
+            result = analyze_filing_with_usage(
+                ExtractedFiling(cik="", accession_number=release_id),
+                snapshot, ticker, messages=messages,
+            )
             analysis_data = result.analysis.model_dump()
             analysis_data["token_usage"] = result.token_usage.model_dump()
             analyzed_at = et_now_iso()

--- a/src/modules/events/eight_k_scanner/us_gnw_handler.py
+++ b/src/modules/events/eight_k_scanner/us_gnw_handler.py
@@ -12,6 +12,7 @@ from src.modules.events.eight_k_scanner.config import (
     US_GNW_POLLER_STATE_KEY,
 )
 from src.modules.events.eight_k_scanner.financials import lookup_market_cap
+from src.modules.events.eight_k_scanner.models import PRIndexMeta, PressRelease
 from src.modules.events.eight_k_scanner.newswire.fetcher import fetch_release
 from src.modules.events.eight_k_scanner.newswire.gnw import poll_gnw
 from src.modules.events.eight_k_scanner.storage.s3 import (
@@ -51,13 +52,13 @@ def lambda_handler(event=None, context=None):
     last_seen = _load_last_seen()
 
     all_releases = poll_gnw(GNW_US_FEEDS)
-    all_releases = [r for r in all_releases if r.get("exchange") in ("NYSE", "NASDAQ")]
+    all_releases = [r for r in all_releases if r.exchange in ("NYSE", "NASDAQ")]
 
-    new_releases = []
+    new_releases: list[PressRelease] = []
     newest_ids: dict[str, str] = dict(last_seen) if last_seen else {}
     for release in all_releases:
-        source = release["source"]
-        rid = release["release_id"]
+        source = release.source
+        rid = release.release_id
         if last_seen and rid <= last_seen.get(source, ""):
             continue
         new_releases.append(release)
@@ -75,8 +76,8 @@ def lambda_handler(event=None, context=None):
     skipped = 0
 
     for release in new_releases:
-        ticker = release.get("ticker", "")
-        release_id = release["release_id"]
+        ticker = release.ticker
+        release_id = release.release_id
 
         if not ticker:
             filtered_out += 1
@@ -96,27 +97,26 @@ def lambda_handler(event=None, context=None):
             pass
 
         try:
-            result = fetch_release(release["url"], release["source"])
+            result = fetch_release(release.url, release.source)
             extracted_at = et_now_iso()
 
-            meta = {
-                "ticker": ticker,
-                "exchange": release.get("exchange", ""),
-                "market_cap": mcap,
-                "release_id": release_id,
-                "title": release["title"],
-                "url": release["url"],
-                "published_at": release["published_at"],
-                "source": release["source"],
-                "extracted_at": extracted_at,
-                "analyzed_at": None,
-            }
+            meta = PRIndexMeta(
+                ticker=ticker,
+                exchange=release.exchange,
+                market_cap=mcap,
+                release_id=release_id,
+                title=release.title,
+                url=release.url,
+                published_at=release.published_at,
+                source=release.source,
+                extracted_at=extracted_at,
+            )
 
-            write_json_to_s3(S3_BUCKET, f"{prefix}/index.json", meta)
+            write_json_to_s3(S3_BUCKET, f"{prefix}/index.json", meta.model_dump())
             get_s3_client().put_object(
                 Bucket=S3_BUCKET,
                 Key=f"{prefix}/release.txt",
-                Body=result["text"],
+                Body=result.text,
                 ContentType="text/plain",
             )
             stored += 1


### PR DESCRIPTION
## Summary
- Adds `models.py` with Pydantic models (`FilingMeta`, `PolledFiling`, `ExtractedFiling`, `FinancialSnapshot`, `PressRelease`, `UniverseInfo`, `PRIndexMeta`, etc.) to replace untyped dicts throughout the 8k-scanner pipeline
- Updates all 22 source files (pollers, fetchers, extractors, analyzers, handlers, universe filters) to construct and consume typed models instead of raw dicts
- S3 serialization format is unchanged -- models use `.model_dump()` before writing JSON

Partially addresses #5.

## Test plan
- [ ] Verify `python -c "from src.modules.events.eight_k_scanner.models import *"` imports cleanly
- [ ] Spot-check that handler Lambda signatures still match expected event shapes
- [ ] Run existing integration tests if any

🤖 Generated with [Claude Code](https://claude.com/claude-code)