### PR TITLE
Add data ingestion module (v2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+EODHD_API_KEY=your_key_here
+ROICAI_API_KEY=your_key_here

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -4,6 +4,7 @@ import json
 import shutil
 from pathlib import Path
 
+import boto3
 import click
 import yaml
 
@@ -118,11 +119,28 @@ def universe_add(ticker: str):
     uploaded = upload_directory(s3, config_dir, "config")
     click.echo(f"Synced {len(uploaded)} config file(s) to S3.")
 
-    # Stub: invoke data ingestion Lambda
+    # Invoke data ingestion Lambda
     click.echo()
-    click.echo(f"[STUB] Would invoke data ingestion Lambda for {ticker} (CIK: {info.cik})")
-    click.echo(f"  This will pull SEC filings, fundamentals, and transcripts to:")
-    click.echo(f"  s3://{BUCKET}/data/research/{ticker}/data/")
+    click.echo(f"Invoking data ingestion for {ticker} (CIK: {info.cik})...")
+    try:
+        lambda_client = boto3.client("lambda")
+        payload = json.dumps({"ticker": ticker, "cik": info.cik})
+        response = lambda_client.invoke(
+            FunctionName="praxis-data-ingestion",
+            InvocationType="Event",  # async — don't wait
+            Payload=payload,
+        )
+        status = response.get("StatusCode", 0)
+        if status in (200, 202):
+            click.echo(f"  Data ingestion triggered (async). Data will appear at:")
+            click.echo(f"  s3://{BUCKET}/data/research/{ticker}/data/")
+        else:
+            click.echo(f"  Lambda invocation returned status {status}")
+    except Exception as e:
+        click.echo(f"  Could not invoke ingestion Lambda: {e}")
+        click.echo(f"  You can run ingestion locally with:")
+        click.echo(f'    python -c "from modules.data_ingestion.handler import handler; '
+                   f"handler({{'ticker': '{ticker}', 'cik': '{info.cik}'}})\"")
 
 
 @universe.command("remove")

--- a/src/modules/data_ingestion/__init__.py
+++ b/src/modules/data_ingestion/__init__.py
@@ -1,0 +1,1 @@
+"""Data ingestion module — pulls research data when a ticker is added to the universe."""

--- a/src/modules/data_ingestion/fundamentals.py
+++ b/src/modules/data_ingestion/fundamentals.py
@@ -1,0 +1,132 @@
+"""Fundamentals data ingestion — three-tier fallback: EODHD -> ROIC.AI -> yfinance."""
+
+import json
+import logging
+import os
+
+import requests
+import yfinance as yf
+
+from modules.data_ingestion.models import FundamentalsData
+
+logger = logging.getLogger(__name__)
+
+
+def _try_eodhd(ticker: str) -> FundamentalsData | None:
+    """Try fetching fundamentals from EODHD API."""
+    api_key = os.environ.get("EODHD_API_KEY", "")
+    if not api_key:
+        logger.info("EODHD_API_KEY not set, skipping EODHD")
+        return None
+
+    url = f"https://eodhd.com/api/fundamentals/{ticker}.US"
+    params = {"api_token": api_key, "fmt": "json"}
+
+    try:
+        resp = requests.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+
+        if not data or isinstance(data, list):
+            logger.warning(f"EODHD returned empty/unexpected data for {ticker}")
+            return None
+
+        return FundamentalsData(source="eodhd", raw=data)
+    except requests.RequestException as e:
+        logger.warning(f"EODHD request failed for {ticker}: {e}")
+        return None
+    except (ValueError, json.JSONDecodeError) as e:
+        logger.warning(f"EODHD returned invalid JSON for {ticker}: {e}")
+        return None
+
+
+def _try_roicai(ticker: str) -> FundamentalsData | None:
+    """Try fetching fundamentals from ROIC.AI API."""
+    api_key = os.environ.get("ROICAI_API_KEY", "")
+    if not api_key:
+        logger.info("ROICAI_API_KEY not set, skipping ROIC.AI")
+        return None
+
+    url = f"https://roic.ai/api/fundamentals/{ticker}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    try:
+        resp = requests.get(url, headers=headers, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+
+        if not data:
+            logger.warning(f"ROIC.AI returned empty data for {ticker}")
+            return None
+
+        return FundamentalsData(source="roicai", raw=data)
+    except requests.RequestException as e:
+        logger.warning(f"ROIC.AI request failed for {ticker}: {e}")
+        return None
+    except (ValueError, json.JSONDecodeError) as e:
+        logger.warning(f"ROIC.AI returned invalid JSON for {ticker}: {e}")
+        return None
+
+
+def _try_yfinance(ticker: str) -> FundamentalsData | None:
+    """Try fetching fundamentals from yfinance (worst-case fallback)."""
+    try:
+        yticker = yf.Ticker(ticker)
+        info = yticker.info or {}
+
+        # Pull all available financial data
+        data: dict = {"info": info}
+
+        try:
+            financials = yticker.financials
+            if financials is not None and not financials.empty:
+                data["financials"] = json.loads(financials.to_json())
+        except Exception:
+            pass
+
+        try:
+            balance_sheet = yticker.balance_sheet
+            if balance_sheet is not None and not balance_sheet.empty:
+                data["balance_sheet"] = json.loads(balance_sheet.to_json())
+        except Exception:
+            pass
+
+        try:
+            cashflow = yticker.cashflow
+            if cashflow is not None and not cashflow.empty:
+                data["cashflow"] = json.loads(cashflow.to_json())
+        except Exception:
+            pass
+
+        if not info and "financials" not in data:
+            logger.warning(f"yfinance returned no data for {ticker}")
+            return None
+
+        return FundamentalsData(source="yfinance", raw=data)
+    except Exception as e:
+        logger.warning(f"yfinance failed for {ticker}: {e}")
+        return None
+
+
+def ingest_fundamentals(ticker: str) -> FundamentalsData | None:
+    """Pull fundamental data using three-tier fallback.
+
+    Tries EODHD first, then ROIC.AI, then yfinance. Returns the first
+    successful result, or None if all sources fail.
+    """
+    sources = [
+        ("EODHD", _try_eodhd),
+        ("ROIC.AI", _try_roicai),
+        ("yfinance", _try_yfinance),
+    ]
+
+    for name, fetch_fn in sources:
+        logger.info(f"Trying {name} for {ticker} fundamentals...")
+        result = fetch_fn(ticker)
+        if result is not None:
+            logger.info(f"Got fundamentals for {ticker} from {name}")
+            return result
+        logger.info(f"{name} unavailable for {ticker}, trying next source")
+
+    logger.warning(f"All fundamental data sources failed for {ticker}")
+    return None

--- a/src/modules/data_ingestion/handler.py
+++ b/src/modules/data_ingestion/handler.py
@@ -1,0 +1,89 @@
+"""Lambda handler for data ingestion — entry point for ticker data pull."""
+
+import json
+import logging
+
+import boto3
+
+from modules.data_ingestion.fundamentals import ingest_fundamentals
+from modules.data_ingestion.models import IngestionResult
+from modules.data_ingestion.sec_filings import ingest_sec_filings
+from modules.data_ingestion.transcripts import ingest_transcripts
+
+logger = logging.getLogger(__name__)
+
+S3_BUCKET = "praxis-copilot"
+
+
+def _upload_to_s3(s3_client, key: str, body: str | bytes) -> None:
+    """Upload content to S3."""
+    if isinstance(body, str):
+        body = body.encode("utf-8")
+    s3_client.put_object(Bucket=S3_BUCKET, Key=key, Body=body)
+
+
+def handler(event: dict, context=None) -> dict:
+    """Lambda entry point for data ingestion.
+
+    Expects event: {"ticker": "NVDA", "cik": "0001045810"}
+    Runs all three ingestion steps with error isolation.
+    """
+    ticker = event["ticker"].upper()
+    cik = event["cik"]
+
+    logging.basicConfig(level=logging.INFO)
+    logger.info(f"Starting data ingestion for {ticker} (CIK: {cik})")
+
+    result = IngestionResult(ticker=ticker)
+    s3 = boto3.client("s3")
+    base_prefix = f"data/research/{ticker}/data"
+
+    # 1. SEC Filings
+    try:
+        sections = ingest_sec_filings(cik, ticker)
+        for section in sections:
+            s3_key = (
+                f"{base_prefix}/filings/{section.filing_type}/"
+                f"{section.period}/{section.section_name}.txt"
+            )
+            _upload_to_s3(s3, s3_key, section.text)
+        result.filings_count = len(sections)
+        logger.info(f"Ingested {len(sections)} filing sections for {ticker}")
+    except Exception as e:
+        msg = f"SEC filings ingestion failed for {ticker}: {e}"
+        logger.warning(msg)
+        result.warnings.append(msg)
+
+    # 2. Fundamentals
+    try:
+        fundamentals = ingest_fundamentals(ticker)
+        if fundamentals:
+            s3_key = f"{base_prefix}/fundamentals/fundamentals.json"
+            _upload_to_s3(s3, s3_key, json.dumps(fundamentals.model_dump(), default=str))
+            result.fundamentals_source = fundamentals.source
+            logger.info(f"Ingested fundamentals for {ticker} from {fundamentals.source}")
+        else:
+            msg = f"No fundamental data available for {ticker}"
+            logger.warning(msg)
+            result.warnings.append(msg)
+    except Exception as e:
+        msg = f"Fundamentals ingestion failed for {ticker}: {e}"
+        logger.warning(msg)
+        result.warnings.append(msg)
+
+    # 3. Transcripts
+    try:
+        transcripts = ingest_transcripts(ticker)
+        for transcript in transcripts:
+            quarter = transcript["quarter"].replace("/", "-").replace(" ", "_")
+            s3_key = f"{base_prefix}/transcripts/{quarter}.txt"
+            _upload_to_s3(s3, s3_key, transcript["text"])
+        result.transcripts_count = len(transcripts)
+        logger.info(f"Ingested {len(transcripts)} transcript(s) for {ticker}")
+    except Exception as e:
+        msg = f"Transcript ingestion failed for {ticker}: {e}"
+        logger.warning(msg)
+        result.warnings.append(msg)
+
+    logger.info(f"Ingestion complete for {ticker}: {result.model_dump()}")
+    return result.model_dump()

--- a/src/modules/data_ingestion/models.py
+++ b/src/modules/data_ingestion/models.py
@@ -1,0 +1,29 @@
+"""Pydantic models for data ingestion results."""
+
+from pydantic import BaseModel, Field
+
+
+class FilingSection(BaseModel):
+    """An extracted narrative section from an SEC filing."""
+
+    filing_type: str = Field(description="10-K or 10-Q")
+    period: str = Field(description="Filing period, e.g. 2024-12-31")
+    section_name: str = Field(description="e.g. item1_business, item7_mda")
+    text: str = Field(description="Extracted plain text content")
+
+
+class FundamentalsData(BaseModel):
+    """Key fundamental metrics with source attribution."""
+
+    source: str = Field(description="eodhd, roicai, or yfinance")
+    raw: dict = Field(default_factory=dict, description="Raw API response data")
+
+
+class IngestionResult(BaseModel):
+    """Summary of what was pulled during data ingestion."""
+
+    ticker: str
+    filings_count: int = 0
+    fundamentals_source: str | None = None
+    transcripts_count: int = 0
+    warnings: list[str] = Field(default_factory=list)

--- a/src/modules/data_ingestion/sec_filings.py
+++ b/src/modules/data_ingestion/sec_filings.py
@@ -1,0 +1,296 @@
+"""SEC filing ingestion — pulls 10-K and 10-Q filings from EDGAR and extracts narrative sections."""
+
+import logging
+import re
+import time
+
+import requests
+from bs4 import BeautifulSoup
+
+from modules.data_ingestion.models import FilingSection
+
+logger = logging.getLogger(__name__)
+
+SEC_HEADERS = {
+    "User-Agent": "PraxisCopilot/0.1 (research-tool)",
+    "Accept-Encoding": "gzip, deflate",
+}
+
+SUBMISSIONS_URL = "https://data.sec.gov/submissions/CIK{cik}.json"
+ARCHIVES_BASE = "https://www.sec.gov/Archives/edgar/data"
+
+# Sections to extract from 10-K
+TENK_SECTIONS = {
+    "item1_business": r"item\s*1[\.\s:\-]*business",
+    "item1a_risk_factors": r"item\s*1a[\.\s:\-]*risk\s*factors",
+    "item7_mda": r"item\s*7[\.\s:\-]*management.{0,5}s?\s*discussion\s*and\s*analysis",
+    "item7a_market_risk": r"item\s*7a[\.\s:\-]*quantitative\s*and\s*qualitative",
+}
+
+# Sections to extract from 10-Q
+TENQ_SECTIONS = {
+    "item2_mda": r"(?:part\s*i[,.\s]*)?item\s*2[\.\s:\-]*management.{0,5}s?\s*discussion\s*and\s*analysis",
+    "item1a_risk_factors": r"(?:part\s*i[,.\s]*)?item\s*1a[\.\s:\-]*risk\s*factors",
+}
+
+# All possible section headers for finding boundaries
+ALL_ITEM_PATTERNS = [
+    r"item\s*1a",
+    r"item\s*1b",
+    r"item\s*1c",
+    r"item\s*1[\.\s]",
+    r"item\s*2",
+    r"item\s*3",
+    r"item\s*4",
+    r"item\s*5",
+    r"item\s*6",
+    r"item\s*7a",
+    r"item\s*7",
+    r"item\s*8",
+    r"item\s*9a",
+    r"item\s*9b",
+    r"item\s*9",
+    r"item\s*10",
+    r"item\s*11",
+    r"item\s*12",
+    r"item\s*13",
+    r"item\s*14",
+    r"item\s*15",
+    r"part\s*i{1,3}",
+    r"signatures",
+]
+
+# Rate limit: SEC allows 10 req/sec, we'll be conservative
+_last_request_time = 0.0
+_min_interval = 0.15
+
+
+def _rate_limit():
+    """Enforce rate limiting for SEC requests."""
+    global _last_request_time
+    now = time.monotonic()
+    elapsed = now - _last_request_time
+    if elapsed < _min_interval:
+        time.sleep(_min_interval - elapsed)
+    _last_request_time = time.monotonic()
+
+
+def _sec_get(url: str) -> requests.Response:
+    """Make a rate-limited GET request to SEC."""
+    _rate_limit()
+    resp = requests.get(url, headers=SEC_HEADERS, timeout=30)
+    resp.raise_for_status()
+    return resp
+
+
+def get_filing_urls(cik: str, filing_type: str, count: int) -> list[dict]:
+    """Get recent filing URLs from EDGAR submissions API.
+
+    Returns list of dicts with keys: accession, period, primary_doc_url
+    """
+    cik_padded = cik.lstrip("0").zfill(10)
+    url = SUBMISSIONS_URL.format(cik=cik_padded)
+
+    try:
+        resp = _sec_get(url)
+        data = resp.json()
+    except (requests.RequestException, ValueError) as e:
+        logger.warning(f"Failed to fetch submissions for CIK {cik}: {e}")
+        return []
+
+    recent = data.get("filings", {}).get("recent", {})
+    forms = recent.get("form", [])
+    accessions = recent.get("accessionNumber", [])
+    primary_docs = recent.get("primaryDocument", [])
+    dates = recent.get("reportDate", [])
+
+    results = []
+    cik_num = cik.lstrip("0")
+
+    for i, form in enumerate(forms):
+        if form != filing_type:
+            continue
+        if len(results) >= count:
+            break
+
+        accession = accessions[i]
+        accession_nodash = accession.replace("-", "")
+        primary_doc = primary_docs[i]
+        period = dates[i] if i < len(dates) else "unknown"
+
+        doc_url = f"{ARCHIVES_BASE}/{cik_num}/{accession_nodash}/{primary_doc}"
+        results.append({
+            "accession": accession,
+            "period": period,
+            "primary_doc_url": doc_url,
+        })
+
+    return results
+
+
+def _clean_text(html_text: str) -> str:
+    """Strip HTML tags and clean whitespace from extracted text."""
+    soup = BeautifulSoup(html_text, "lxml")
+
+    # Remove script and style elements
+    for element in soup(["script", "style"]):
+        element.decompose()
+
+    text = soup.get_text(separator="\n")
+
+    # Clean up whitespace
+    lines = []
+    for line in text.splitlines():
+        cleaned = line.strip()
+        if cleaned:
+            lines.append(cleaned)
+
+    text = "\n".join(lines)
+
+    # Collapse runs of 3+ newlines into 2
+    text = re.sub(r"\n{3,}", "\n\n", text)
+
+    return text.strip()
+
+
+def _extract_sections_from_html(html: str, section_patterns: dict[str, str]) -> dict[str, str]:
+    """Extract named sections from an SEC filing HTML document.
+
+    Uses regex to find section header boundaries and extract text between them.
+    """
+    # First pass: get full text with position tracking
+    soup = BeautifulSoup(html, "lxml")
+
+    # Remove tables to avoid financial data noise
+    for table in soup.find_all("table"):
+        table.decompose()
+
+    # Get text content
+    full_text = soup.get_text(separator="\n")
+
+    results = {}
+
+    for section_name, pattern in section_patterns.items():
+        try:
+            extracted = _extract_section(full_text, pattern)
+            if extracted and len(extracted.strip()) > 200:
+                results[section_name] = extracted.strip()
+            else:
+                logger.debug(f"Section {section_name} too short or not found")
+        except Exception as e:
+            logger.debug(f"Failed to extract {section_name}: {e}")
+
+    return results
+
+
+def _extract_section(text: str, start_pattern: str) -> str | None:
+    """Extract a section from text by finding its header and the next section header."""
+    # Find the start of this section
+    match = re.search(start_pattern, text, re.IGNORECASE)
+    if not match:
+        return None
+
+    start_pos = match.start()
+
+    # Find the start of the next section after this one
+    # Look for any item/part header that comes after our section
+    best_end = len(text)
+    search_from = match.end() + 100  # skip at least 100 chars past the header
+
+    for next_pattern in ALL_ITEM_PATTERNS:
+        # Skip the pattern that matches our own section
+        if re.search(next_pattern, match.group(0), re.IGNORECASE):
+            continue
+
+        # Find occurrences of the next section pattern
+        for next_match in re.finditer(next_pattern, text[search_from:], re.IGNORECASE):
+            candidate_pos = search_from + next_match.start()
+
+            # Verify this looks like a real section header (often on its own line or bold)
+            # Check that the text around it looks like a header
+            line_start = text.rfind("\n", 0, candidate_pos)
+            if line_start == -1:
+                line_start = 0
+            prefix = text[line_start:candidate_pos].strip()
+
+            # Real headers typically have little text before them on the line
+            if len(prefix) < 30 and candidate_pos < best_end:
+                best_end = candidate_pos
+            break
+
+    section_text = text[start_pos:best_end]
+
+    # Clean up: remove the header line itself from the content
+    lines = section_text.split("\n")
+    # Skip first few lines that are the header
+    content_lines = []
+    past_header = False
+    for line in lines:
+        if not past_header:
+            if re.search(start_pattern, line, re.IGNORECASE):
+                past_header = True
+                continue
+        if past_header:
+            content_lines.append(line)
+
+    result = "\n".join(content_lines).strip()
+
+    # Clean whitespace
+    result = re.sub(r"\n{3,}", "\n\n", result)
+    result = re.sub(r"[ \t]+", " ", result)
+
+    return result
+
+
+def ingest_sec_filings(cik: str, ticker: str) -> list[FilingSection]:
+    """Pull SEC filings and extract narrative sections.
+
+    Returns list of FilingSection objects.
+    """
+    all_sections: list[FilingSection] = []
+
+    # Pull most recent 10-K
+    logger.info(f"Fetching 10-K filings for {ticker} (CIK: {cik})")
+    tenk_filings = get_filing_urls(cik, "10-K", count=1)
+
+    for filing in tenk_filings:
+        try:
+            logger.info(f"  Fetching 10-K for period {filing['period']}")
+            resp = _sec_get(filing["primary_doc_url"])
+            html = resp.text
+
+            sections = _extract_sections_from_html(html, TENK_SECTIONS)
+            for section_name, text in sections.items():
+                all_sections.append(FilingSection(
+                    filing_type="10-K",
+                    period=filing["period"],
+                    section_name=section_name,
+                    text=text,
+                ))
+            logger.info(f"  Extracted {len(sections)} sections from 10-K")
+        except requests.RequestException as e:
+            logger.warning(f"  Failed to fetch 10-K document: {e}")
+
+    # Pull last 4 10-Qs
+    logger.info(f"Fetching 10-Q filings for {ticker} (CIK: {cik})")
+    tenq_filings = get_filing_urls(cik, "10-Q", count=4)
+
+    for filing in tenq_filings:
+        try:
+            logger.info(f"  Fetching 10-Q for period {filing['period']}")
+            resp = _sec_get(filing["primary_doc_url"])
+            html = resp.text
+
+            sections = _extract_sections_from_html(html, TENQ_SECTIONS)
+            for section_name, text in sections.items():
+                all_sections.append(FilingSection(
+                    filing_type="10-Q",
+                    period=filing["period"],
+                    section_name=section_name,
+                    text=text,
+                ))
+            logger.info(f"  Extracted {len(sections)} sections from 10-Q ({filing['period']})")
+        except requests.RequestException as e:
+            logger.warning(f"  Failed to fetch 10-Q document: {e}")
+
+    return all_sections

--- a/src/modules/data_ingestion/transcripts.py
+++ b/src/modules/data_ingestion/transcripts.py
@@ -1,0 +1,49 @@
+"""Earnings call transcript ingestion — best-effort pull from ROIC.AI."""
+
+import json
+import logging
+import os
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def ingest_transcripts(ticker: str) -> list[dict]:
+    """Pull earnings call transcripts from ROIC.AI.
+
+    Returns list of dicts with keys: quarter, text.
+    This is best-effort — returns empty list if unavailable.
+    """
+    api_key = os.environ.get("ROICAI_API_KEY", "")
+    if not api_key:
+        logger.warning("ROICAI_API_KEY not set, skipping transcript ingestion")
+        return []
+
+    url = f"https://roic.ai/api/transcripts/{ticker}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    try:
+        resp = requests.get(url, headers=headers, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+    except requests.RequestException as e:
+        logger.warning(f"Failed to fetch transcripts for {ticker}: {e}")
+        return []
+    except (ValueError, json.JSONDecodeError) as e:
+        logger.warning(f"Invalid transcript response for {ticker}: {e}")
+        return []
+
+    if not data or not isinstance(data, list):
+        logger.warning(f"No transcripts available for {ticker}")
+        return []
+
+    transcripts = []
+    for entry in data:
+        quarter = entry.get("quarter") or entry.get("period", "unknown")
+        text = entry.get("text") or entry.get("transcript", "")
+        if text:
+            transcripts.append({"quarter": str(quarter), "text": str(text)})
+
+    logger.info(f"Fetched {len(transcripts)} transcript(s) for {ticker}")
+    return transcripts


### PR DESCRIPTION
## Summary
- Adds src/modules/data_ingestion/ with SEC filings, fundamentals, and transcript ingestion
- SEC filings: pulls latest 10-K + 4 10-Qs from EDGAR, extracts narrative sections (Business, Risk Factors, MD&A, Market Risk) using regex-based section boundary detection, stores as individual text files
- Fundamentals: three-tier cascade (EODHD -> ROIC.AI -> yfinance), stores as JSON with source attribution
- Transcripts: best-effort pull from ROIC.AI, stores per-quarter text files
- Lambda handler with error isolation -- one source failing does not block others
- Updates praxis universe add CLI to invoke the ingestion Lambda instead of printing a stub
- Adds .env.example for API keys

Replaces #7.

## Files
- src/modules/data_ingestion/models.py -- Pydantic models (IngestionResult, FilingSection, FundamentalsData)
- src/modules/data_ingestion/sec_filings.py -- EDGAR scraping + section extraction
- src/modules/data_ingestion/fundamentals.py -- API cascade for fundamental data
- src/modules/data_ingestion/transcripts.py -- Earnings transcript pull
- src/modules/data_ingestion/handler.py -- Lambda entry point
- src/cli/main.py -- Updated universe add command
- .env.example -- API key template

Generated with Claude Code