### PR TITLE
Fundamentals MCP server + summary generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pyyaml>=6.0",
     "click>=8.1",
     "python-dotenv>=1.0",
+    "mcp>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/cli/fundamentals_server.py
+++ b/src/cli/fundamentals_server.py
@@ -1,0 +1,240 @@
+"""MCP server for querying fundamentals data during Claude Code research sessions.
+
+Loads a fundamentals.json file and exposes tools for targeted queries,
+so Claude never needs to read the full 700KB+ file into context.
+
+Usage (stdio transport, configured automatically by `praxis stage`):
+    python -m cli.fundamentals_server /path/to/fundamentals.json
+"""
+
+import json
+import sys
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("praxis-fundamentals")
+
+# Loaded at startup from CLI arg
+_data: dict = {}
+_raw: dict = {}
+
+
+def _load(path: str) -> None:
+    global _data, _raw
+    with open(path) as f:
+        _data = json.load(f)
+    _raw = _data.get("raw", _data)
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+def company_overview() -> dict:
+    """Get company overview: highlights, valuation, share stats, dividends, analyst ratings.
+
+    This is the compact summary — call this first to orient yourself.
+    """
+    sections = ["General", "Highlights", "Valuation", "SharesStats",
+                "SplitsDividends", "AnalystRatings", "Technicals"]
+    result = {}
+    for s in sections:
+        if s in _raw:
+            result[s] = _raw[s]
+    return result
+
+
+@mcp.tool()
+def list_financial_metrics(statement: str = "income") -> list[str]:
+    """List available metric names for a financial statement.
+
+    Args:
+        statement: One of 'income', 'balance', 'cashflow'
+    """
+    key_map = {
+        "income": "Income_Statement",
+        "balance": "Balance_Sheet",
+        "cashflow": "Cash_Flow",
+    }
+    stmt_key = key_map.get(statement)
+    if not stmt_key:
+        return [f"Unknown statement '{statement}'. Use: income, balance, cashflow"]
+
+    financials = _raw.get("Financials", {}).get(stmt_key, {})
+    yearly = financials.get("yearly", {})
+    if not yearly:
+        return []
+    sample = list(yearly.values())[0]
+    return sorted(sample.keys())
+
+
+@mcp.tool()
+def get_financial_data(
+    statement: str,
+    metrics: list[str],
+    period_type: str = "yearly",
+    count: int = 5,
+) -> list[dict]:
+    """Get specific metrics from a financial statement for recent periods.
+
+    Args:
+        statement: One of 'income', 'balance', 'cashflow'
+        metrics: List of metric names (use list_financial_metrics to discover them)
+        period_type: 'yearly' or 'quarterly'
+        count: Number of most recent periods to return (max 20)
+    """
+    key_map = {
+        "income": "Income_Statement",
+        "balance": "Balance_Sheet",
+        "cashflow": "Cash_Flow",
+    }
+    stmt_key = key_map.get(statement)
+    if not stmt_key:
+        return [{"error": f"Unknown statement '{statement}'. Use: income, balance, cashflow"}]
+
+    financials = _raw.get("Financials", {}).get(stmt_key, {})
+    periods = financials.get(period_type, {})
+    if not periods:
+        return [{"error": f"No {period_type} data available"}]
+
+    count = min(count, 20)
+    sorted_dates = sorted(periods.keys(), reverse=True)[:count]
+
+    results = []
+    for date in sorted_dates:
+        row = {"date": date}
+        for m in metrics:
+            row[m] = periods[date].get(m)
+        results.append(row)
+
+    return results
+
+
+@mcp.tool()
+def get_full_statement(
+    statement: str,
+    period_type: str = "yearly",
+    count: int = 3,
+) -> list[dict]:
+    """Get ALL metrics from a financial statement for recent periods.
+
+    Use this when you need the complete picture for a few periods.
+    Prefer get_financial_data with specific metrics when possible.
+
+    Args:
+        statement: One of 'income', 'balance', 'cashflow'
+        period_type: 'yearly' or 'quarterly'
+        count: Number of periods (max 5 to avoid context bloat)
+    """
+    key_map = {
+        "income": "Income_Statement",
+        "balance": "Balance_Sheet",
+        "cashflow": "Cash_Flow",
+    }
+    stmt_key = key_map.get(statement)
+    if not stmt_key:
+        return [{"error": f"Unknown statement '{statement}'"}]
+
+    financials = _raw.get("Financials", {}).get(stmt_key, {})
+    periods = financials.get(period_type, {})
+    if not periods:
+        return []
+
+    count = min(count, 5)
+    sorted_dates = sorted(periods.keys(), reverse=True)[:count]
+    return [{"date": d, **periods[d]} for d in sorted_dates]
+
+
+@mcp.tool()
+def get_earnings(count: int = 8) -> dict:
+    """Get recent earnings history and estimates.
+
+    Args:
+        count: Number of recent earnings periods to return
+    """
+    earnings = _raw.get("Earnings", {})
+    result = {}
+
+    history = earnings.get("History", {})
+    if history:
+        sorted_dates = sorted(history.keys(), reverse=True)[:count]
+        result["history"] = {d: history[d] for d in sorted_dates}
+
+    trend = earnings.get("Trend", {})
+    if trend:
+        sorted_dates = sorted(trend.keys(), reverse=True)[:count]
+        result["trend"] = {d: trend[d] for d in sorted_dates}
+
+    annual = earnings.get("Annual", {})
+    if annual:
+        sorted_dates = sorted(annual.keys(), reverse=True)[:min(count, 5)]
+        result["annual"] = {d: annual[d] for d in sorted_dates}
+
+    return result
+
+
+@mcp.tool()
+def get_holders() -> dict:
+    """Get institutional and insider holder information."""
+    result = {}
+    if "Holders" in _raw:
+        result["holders"] = _raw["Holders"]
+    if "InsiderTransactions" in _raw:
+        # Limit to recent transactions
+        txns = _raw["InsiderTransactions"]
+        if isinstance(txns, dict):
+            result["insider_transactions"] = dict(list(txns.items())[:20])
+        elif isinstance(txns, list):
+            result["insider_transactions"] = txns[:20]
+    return result
+
+
+@mcp.tool()
+def search_fundamentals(keyword: str) -> dict:
+    """Search across all fundamentals data for a keyword.
+
+    Useful when you're not sure which statement or section contains
+    the data point you need.
+
+    Args:
+        keyword: Case-insensitive keyword to search for in field names
+    """
+    keyword_lower = keyword.lower()
+    matches = {}
+
+    def _search(obj, path=""):
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                current_path = f"{path}.{k}" if path else k
+                if keyword_lower in k.lower():
+                    if isinstance(v, (str, int, float, type(None))):
+                        matches[current_path] = v
+                    elif isinstance(v, dict) and len(v) < 5:
+                        matches[current_path] = v
+                    else:
+                        matches[current_path] = f"<{type(v).__name__} with {len(v)} items>"
+                elif isinstance(v, dict) and len(path.split(".")) < 3:
+                    _search(v, current_path)
+
+    _search(_raw)
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python -m cli.fundamentals_server <fundamentals.json>", file=sys.stderr)
+        sys.exit(1)
+
+    path = sys.argv[1]
+    if not Path(path).exists():
+        print(f"File not found: {path}", file=sys.stderr)
+        sys.exit(1)
+
+    _load(path)
+    mcp.run()

--- a/src/cli/fundamentals_summary.py
+++ b/src/cli/fundamentals_summary.py
@@ -1,0 +1,212 @@
+"""Generate a compact markdown summary of fundamentals data.
+
+Produces a ~5-10KB readable overview from 700KB+ raw JSON,
+giving Claude orientation before it drills into specifics via MCP tools.
+"""
+
+import json
+
+
+def generate_summary(fundamentals_json: dict) -> str:
+    """Generate markdown summary from fundamentals data."""
+    raw = fundamentals_json.get("raw", fundamentals_json)
+    source = fundamentals_json.get("source", "unknown")
+    sections = []
+
+    # Header
+    general = raw.get("General", {})
+    name = general.get("Name", "Unknown")
+    ticker = general.get("Code", "")
+    exchange = general.get("Exchange", "")
+    sector = general.get("Sector", "")
+    industry = general.get("Industry", "")
+    description = general.get("Description", "")
+
+    sections.append(f"# {name} ({ticker}) — Fundamentals Summary")
+    sections.append(f"*Source: {source} | {exchange} | {sector} > {industry}*\n")
+
+    if description:
+        # Truncate long descriptions
+        if len(description) > 500:
+            description = description[:500] + "..."
+        sections.append(f"> {description}\n")
+
+    # Highlights
+    highlights = raw.get("Highlights", {})
+    if highlights:
+        sections.append("## Key Metrics")
+        rows = [
+            ("Market Cap", _fmt_large(highlights.get("MarketCapitalization"))),
+            ("P/E (TTM)", _fmt_num(highlights.get("PERatio"))),
+            ("PEG Ratio", _fmt_num(highlights.get("PEGRatio"))),
+            ("EPS (TTM)", _fmt_num(highlights.get("EarningsShare"))),
+            ("EPS Est (CY)", _fmt_num(highlights.get("EPSEstimateCurrentYear"))),
+            ("EPS Est (NY)", _fmt_num(highlights.get("EPSEstimateNextYear"))),
+            ("Profit Margin", _fmt_pct(highlights.get("ProfitMargin"))),
+            ("Operating Margin", _fmt_pct(highlights.get("OperatingMarginTTM"))),
+            ("ROE", _fmt_pct(highlights.get("ReturnOnEquityTTM"))),
+            ("ROA", _fmt_pct(highlights.get("ReturnOnAssetsTTM"))),
+            ("EBITDA", _fmt_large(highlights.get("EBITDA"))),
+            ("Book Value", _fmt_num(highlights.get("BookValue"))),
+            ("Dividend Yield", _fmt_pct(highlights.get("DividendYield"))),
+            ("Wall St Target", _fmt_num(highlights.get("WallStreetTargetPrice"))),
+        ]
+        sections.append(_make_table(["Metric", "Value"], rows))
+
+    # Valuation
+    valuation = raw.get("Valuation", {})
+    if valuation:
+        sections.append("## Valuation")
+        rows = [
+            ("Trailing P/E", _fmt_num(valuation.get("TrailingPE"))),
+            ("Forward P/E", _fmt_num(valuation.get("ForwardPE"))),
+            ("P/S (TTM)", _fmt_num(valuation.get("PriceSalesTTM"))),
+            ("P/B (MRQ)", _fmt_num(valuation.get("PriceBookMRQ"))),
+            ("EV", _fmt_large(valuation.get("EnterpriseValue"))),
+            ("EV/Revenue", _fmt_num(valuation.get("EnterpriseValueRevenue"))),
+            ("EV/EBITDA", _fmt_num(valuation.get("EnterpriseValueEbitda"))),
+        ]
+        sections.append(_make_table(["Metric", "Value"], rows))
+
+    # Income Statement — last 5 years
+    _add_statement_table(
+        sections, raw, "Income_Statement", "yearly", 5,
+        "## Income Statement (Annual)",
+        ["totalRevenue", "costOfRevenue", "grossProfit", "operatingIncome", "netIncome",
+         "ebitda", "researchDevelopment", "sellingGeneralAdministrative"],
+    )
+
+    # Income Statement — last 6 quarters
+    _add_statement_table(
+        sections, raw, "Income_Statement", "quarterly", 6,
+        "## Income Statement (Quarterly)",
+        ["totalRevenue", "grossProfit", "operatingIncome", "netIncome", "ebitda"],
+    )
+
+    # Balance Sheet — last 5 years
+    _add_statement_table(
+        sections, raw, "Balance_Sheet", "yearly", 5,
+        "## Balance Sheet (Annual)",
+        ["totalAssets", "totalCurrentAssets", "cashAndShortTermInvestments",
+         "totalLiab", "totalCurrentLiabilities", "longTermDebt",
+         "shortLongTermDebt", "totalStockholderEquity"],
+    )
+
+    # Cash Flow — last 5 years
+    _add_statement_table(
+        sections, raw, "Cash_Flow", "yearly", 5,
+        "## Cash Flow (Annual)",
+        ["totalCashFromOperatingActivities", "capitalExpenditures",
+         "freeCashFlow", "totalCashFromFinancingActivities",
+         "dividendsPaid", "salePurchaseOfStock"],
+    )
+
+    # Shares outstanding trend
+    outstanding = raw.get("outstandingShares", {})
+    if isinstance(outstanding, dict):
+        annual = outstanding.get("annual", {})
+        if annual:
+            sections.append("## Shares Outstanding")
+            # annual may be a dict keyed by index strings or a list
+            entries = list(annual.values()) if isinstance(annual, dict) else annual
+            rows = []
+            for entry in entries[:5]:
+                if isinstance(entry, dict):
+                    date = entry.get("date", "?")
+                    shares = entry.get("shares")
+                    rows.append((date, _fmt_large(shares)))
+            if rows:
+                sections.append(_make_table(["Date", "Shares"], rows))
+
+    # Footer
+    sections.append("\n---")
+    sections.append("*For detailed drill-down, use the `fundamentals` MCP tools "
+                    "(get_financial_data, get_earnings, search_fundamentals, etc.)*")
+
+    return "\n\n".join(sections)
+
+
+def _add_statement_table(
+    sections: list, raw: dict, stmt_key: str, period_type: str,
+    count: int, header: str, metrics: list[str],
+) -> None:
+    """Add a financial statement table to sections."""
+    financials = raw.get("Financials", {}).get(stmt_key, {})
+    periods = financials.get(period_type, {})
+    if not periods:
+        return
+
+    sorted_dates = sorted(periods.keys(), reverse=True)[:count]
+    # Use short date labels
+    labels = [d[:10] for d in sorted_dates]
+
+    sections.append(header)
+    header_row = ["Metric"] + labels
+    rows = []
+    for metric in metrics:
+        row_vals = [_clean_metric_name(metric)]
+        for d in sorted_dates:
+            val = periods[d].get(metric)
+            row_vals.append(_fmt_large(val))
+        rows.append(tuple(row_vals))
+
+    sections.append(_make_table(header_row, rows))
+
+
+def _make_table(headers: list[str], rows: list[tuple]) -> str:
+    """Build a markdown table."""
+    lines = ["| " + " | ".join(headers) + " |"]
+    lines.append("| " + " | ".join(["---"] * len(headers)) + " |")
+    for row in rows:
+        lines.append("| " + " | ".join(str(v) for v in row) + " |")
+    return "\n".join(lines)
+
+
+def _fmt_num(val) -> str:
+    if val is None:
+        return "—"
+    try:
+        val = float(val)
+        if abs(val) >= 100:
+            return f"{val:,.0f}"
+        return f"{val:,.2f}"
+    except (ValueError, TypeError):
+        return str(val)
+
+
+def _fmt_large(val) -> str:
+    if val is None:
+        return "—"
+    try:
+        val = float(val)
+    except (ValueError, TypeError):
+        return str(val)
+    abs_val = abs(val)
+    sign = "-" if val < 0 else ""
+    if abs_val >= 1e12:
+        return f"{sign}${abs_val / 1e12:,.1f}T"
+    if abs_val >= 1e9:
+        return f"{sign}${abs_val / 1e9:,.1f}B"
+    if abs_val >= 1e6:
+        return f"{sign}${abs_val / 1e6:,.0f}M"
+    if abs_val >= 1e3:
+        return f"{sign}${abs_val / 1e3:,.0f}K"
+    return f"{sign}${val:,.0f}"
+
+
+def _fmt_pct(val) -> str:
+    if val is None:
+        return "—"
+    try:
+        val = float(val)
+        return f"{val * 100:.1f}%" if abs(val) < 1 else f"{val:.1f}%"
+    except (ValueError, TypeError):
+        return str(val)
+
+
+def _clean_metric_name(name: str) -> str:
+    """Convert camelCase to readable form."""
+    import re
+    # Insert spaces before capitals
+    spaced = re.sub(r"([a-z])([A-Z])", r"\1 \2", name)
+    return spaced.replace("_", " ").title()

--- a/src/cli/ingest/__init__.py
+++ b/src/cli/ingest/__init__.py
@@ -3,6 +3,7 @@
 import json
 import logging
 
+from cli.fundamentals_summary import generate_summary
 from cli.ingest.fundamentals import ingest_fundamentals
 from cli.ingest.models import IngestionResult
 from cli.ingest.sec_filings import ingest_sec_filings
@@ -43,8 +44,14 @@ def run_ingestion(ticker: str, cik: str, s3_client) -> IngestionResult:
     try:
         fundamentals = ingest_fundamentals(ticker)
         if fundamentals:
+            raw_data = fundamentals.model_dump()
+            # Upload raw JSON (for MCP server to query)
             s3_key = f"{base_prefix}/fundamentals/fundamentals.json"
-            _upload(s3_client, s3_key, json.dumps(fundamentals.model_dump(), default=str))
+            _upload(s3_client, s3_key, json.dumps(raw_data, default=str))
+            # Upload compact summary (for Claude to read directly)
+            summary = generate_summary(raw_data)
+            s3_key_summary = f"{base_prefix}/fundamentals/summary.md"
+            _upload(s3_client, s3_key_summary, summary)
             result.fundamentals_source = fundamentals.source
             logger.info(f"Ingested fundamentals from {fundamentals.source}")
         else:

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -306,16 +306,38 @@ def stage(ticker: str):
     claude_md_path.write_text(prompt)
     click.echo(f"  Generated CLAUDE.md (depth: {budget.depth_label})")
 
+    # Configure MCP server for fundamentals querying
+    fundamentals_path = data_dir / "fundamentals" / "fundamentals.json"
+    if fundamentals_path.exists():
+        server_script = str(Path(__file__).parent / "fundamentals_server.py")
+        mcp_config = {
+            "mcpServers": {
+                "fundamentals": {
+                    "command": sys.executable,
+                    "args": [server_script, str(fundamentals_path)],
+                }
+            }
+        }
+        mcp_path = workspace / ".mcp.json"
+        mcp_path.write_text(json.dumps(mcp_config, indent=2))
+        click.echo(f"  Configured fundamentals MCP server")
+
     click.echo(f"\nWorkspace ready: {workspace}")
     click.echo(f"  cd {workspace} && claude")
     click.echo(f"  After analysis: praxis research sync {ticker}")
 
 
 def _build_manifest(data_dir: Path) -> str:
-    """Build a file listing for the research prompt."""
+    """Build a file listing for the research prompt.
+
+    Excludes fundamentals.json (too large for context — use MCP tools instead).
+    """
     lines = []
     for path in sorted(data_dir.rglob("*")):
         if path.is_file():
+            # Skip raw fundamentals JSON — Claude uses MCP tools for that
+            if path.name == "fundamentals.json":
+                continue
             relative = path.relative_to(data_dir)
             size = path.stat().st_size
             if size > 1024:


### PR DESCRIPTION
## Summary
- **MCP server** (`fundamentals_server.py`): Claude Code queries fundamentals on-demand via tool calls instead of reading 700KB+ JSON into context. Tools: `company_overview`, `get_financial_data`, `get_full_statement`, `get_earnings`, `list_financial_metrics`, `get_holders`, `search_fundamentals`
- **Summary generator** (`fundamentals_summary.py`): Produces ~4KB markdown overview at ingestion time — key metrics, valuation, income/balance/cashflow tables for recent periods
- `praxis stage` auto-writes `.mcp.json` so Claude Code picks up the server automatically
- Manifest excludes `fundamentals.json` from direct file listing

## Flow
1. `praxis universe add` → ingests fundamentals → generates both `fundamentals.json` and `summary.md`
2. `praxis stage` → pulls data, writes `.mcp.json` pointing at the MCP server
3. `cd workspace/NVDA && claude` → Claude reads `summary.md` for orientation, calls MCP tools for drill-down

## Test plan
- [ ] `praxis universe add NVDA` generates both fundamentals.json and summary.md on S3
- [ ] `praxis stage NVDA` creates `.mcp.json` in workspace
- [ ] Claude Code session in workspace can call fundamentals tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)