### PR TITLE
Parallel claude messaging + research sync-all default

### DIFF
--- a/scripts/parallel_claude.py
+++ b/scripts/parallel_claude.py
@@ -82,7 +82,7 @@ def main() -> None:
     sessions = {ticker: str(uuid.uuid4()) for ticker in args.tickers}
 
     # Print session IDs upfront for resumability
-    print(f"Launching {len(args.tickers)} sessions (max {args.max_parallel} parallel)\n")
+    print(f"Queued {len(args.tickers)} sessions, running {args.max_parallel} at a time\n")
     for ticker, sid in sessions.items():
         print(f"  {ticker}: {sid}")
     print()

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -593,11 +593,26 @@ def research_pull(ticker: str):
 
 
 @research.command("sync")
-@click.argument("tickers", nargs=-1, required=True)
+@click.argument("tickers", nargs=-1)
 def research_sync(tickers: tuple[str, ...]):
-    """Sync local research artifacts for TICKER(s) to S3 and clean up workspace."""
+    """Sync local research artifacts for TICKER(s) to S3 and clean up workspace.
+
+    If no tickers are given, syncs all workspaces that exist locally.
+    """
     repo_root = find_repo_root()
     s3 = get_s3_client()
+
+    if not tickers:
+        workspace_root = repo_root / "workspace"
+        tickers = tuple(
+            d.name
+            for d in sorted(workspace_root.iterdir())
+            if d.is_dir() and d.name != "macro"
+        )
+        if not tickers:
+            click.echo("No workspaces found to sync.")
+            return
+        click.echo(f"Syncing all {len(tickers)} workspace(s): {', '.join(tickers)}\n")
 
     for ticker in tickers:
         ticker = ticker.upper()


### PR DESCRIPTION
## Summary
- Clearer parallel_claude.py status message ("Queued N sessions, running M at a time")
- `praxis research sync` with no args now syncs all workspaces