### PR TITLE
Fix monitor routing/deploy wiring and add regression tests

### DIFF
--- a/scripts/deploy_8k_events.sh
+++ b/scripts/deploy_8k_events.sh
@@ -44,6 +44,7 @@ CA_ANALYZER_FUNCTION="${CA_ANALYZER_FUNCTION:-8k-scanner-ca-analyzer}"
 US_GNW_POLLER_FUNCTION="${US_GNW_POLLER_FUNCTION:-8k-scanner-us-gnw-poller}"
 US_GNW_ANALYZER_FUNCTION="${US_GNW_ANALYZER_FUNCTION:-8k-scanner-us-gnw-analyzer}"
 DISPATCH_FUNCTION="${DISPATCH_FUNCTION:-8k-scanner-dispatch}"
+MONITOR_EVALUATOR_FUNCTION="${MONITOR_EVALUATOR_FUNCTION:-praxis-monitor-evaluator}"
 
 POLLER_RULE="${POLLER_RULE:-8k-scanner-poller-cron}"
 CA_POLLER_RULE="${CA_POLLER_RULE:-8k-scanner-ca-poller-cron}"
@@ -88,6 +89,25 @@ if ! aws iam get-role --role-name "${ROLE_NAME}" >/dev/null 2>&1; then
 
   echo "Waiting for IAM role propagation..."
   sleep 10
+fi
+
+# Allow dispatch Lambda (running under ROLE_NAME) to invoke the monitor evaluator.
+if ! aws iam put-role-policy \
+  --role-name "${ROLE_NAME}" \
+  --policy-name "AllowInvokeMonitorEvaluator" \
+  --policy-document "{
+    \"Version\": \"2012-10-17\",
+    \"Statement\": [
+      {
+        \"Effect\": \"Allow\",
+        \"Action\": \"lambda:InvokeFunction\",
+        \"Resource\": \"arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${MONITOR_EVALUATOR_FUNCTION}\"
+      }
+    ]
+  }" >/dev/null; then
+  echo "WARN: could not attach inline IAM invoke policy to ${ROLE_NAME}."
+  echo "      If dispatch cannot invoke ${MONITOR_EVALUATOR_FUNCTION}, add a Lambda resource policy"
+  echo "      via aws lambda add-permission on ${MONITOR_EVALUATOR_FUNCTION} for role ${ROLE_NAME}."
 fi
 
 COMMON_VARS="S3_BUCKET=${S3_BUCKET},SEC_USER_AGENT=${SEC_USER_AGENT},FMP_API_KEY=${FMP_API_KEY},EODHD_API_KEY=${EODHD_API_KEY},MARKET_CAP_THRESHOLD=${MARKET_CAP_THRESHOLD},CA_MARKET_CAP_THRESHOLD=${CA_MARKET_CAP_THRESHOLD}"
@@ -219,6 +239,15 @@ aws s3api put-bucket-notification-configuration \
         ]}}
       },
       {
+        \"Id\": \"filings-extractor-index\",
+        \"LambdaFunctionArn\": \"${extractor_arn}\",
+        \"Events\": [\"s3:ObjectCreated:*\"],
+        \"Filter\": {\"Key\": {\"FilterRules\": [
+          {\"Name\": \"Prefix\", \"Value\": \"data/raw/filings/\"},
+          {\"Name\": \"Suffix\", \"Value\": \"index.json\"}
+        ]}}
+      },
+      {
         \"Id\": \"8k-analyzer-extracted\",
         \"LambdaFunctionArn\": \"${analyzer_arn}\",
         \"Events\": [\"s3:ObjectCreated:*\"],
@@ -252,6 +281,15 @@ aws s3api put-bucket-notification-configuration \
         \"Filter\": {\"Key\": {\"FilterRules\": [
           {\"Name\": \"Prefix\", \"Value\": \"data/raw/8k/\"},
           {\"Name\": \"Suffix\", \"Value\": \"analysis.json\"}
+        ]}}
+      },
+      {
+        \"Id\": \"dispatch-filings-extracted\",
+        \"LambdaFunctionArn\": \"${dispatch_arn}\",
+        \"Events\": [\"s3:ObjectCreated:*\"],
+        \"Filter\": {\"Key\": {\"FilterRules\": [
+          {\"Name\": \"Prefix\", \"Value\": \"data/raw/filings/\"},
+          {\"Name\": \"Suffix\", \"Value\": \"extracted.json\"}
         ]}}
       },
       {

--- a/scripts/deploy_monitors.sh
+++ b/scripts/deploy_monitors.sh
@@ -2,6 +2,17 @@
 # Deploy the monitor system: evaluator Lambda, EventBridge rules, S3 notifications
 set -euo pipefail
 
+# Load deploy env if present (same convention as deploy_8k_events.sh)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEPLOY_ENV_FILE="${DEPLOY_ENV_FILE:-${REPO_ROOT}/.env.deploy}"
+if [[ -f "${DEPLOY_ENV_FILE}" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "${DEPLOY_ENV_FILE}"
+    set +a
+fi
+
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 BUCKET="praxis-copilot"
@@ -16,6 +27,13 @@ echo ""
 echo "--- Deploying monitor-evaluator Lambda ---"
 
 EVALUATOR_FUNCTION="${LAMBDA_PREFIX}-monitor-evaluator"
+ENV_VARS="S3_BUCKET=${BUCKET}"
+if [[ -n "${SNS_TOPIC_ARN:-}" ]]; then
+    ENV_VARS="${ENV_VARS},SNS_TOPIC_ARN=${SNS_TOPIC_ARN}"
+fi
+if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+    ENV_VARS="${ENV_VARS},ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}"
+fi
 
 # Check if function exists
 if aws lambda get-function --function-name "$EVALUATOR_FUNCTION" --region "$REGION" 2>/dev/null; then
@@ -35,7 +53,7 @@ else
         --zip-file fileb://dist/monitor-evaluator.zip \
         --timeout 300 \
         --memory-size 512 \
-        --environment "Variables={S3_BUCKET=${BUCKET},SNS_TOPIC_ARN=${SNS_TOPIC_ARN:-}}" \
+        --environment "Variables={${ENV_VARS}}" \
         --region "$REGION" \
         --no-cli-pager
 fi
@@ -80,8 +98,10 @@ DISPATCH_FUNCTION="${LAMBDA_PREFIX}-dispatch"
 # This adds the filings/ prefix trigger alongside existing triggers.
 # See deploy_8k_events.sh for the full notification config.
 
-echo "IMPORTANT: Update the S3 notification configuration in deploy_8k_events.sh"
-echo "to include the new prefix: data/raw/filings/ -> ${DISPATCH_FUNCTION}"
+echo "deploy_8k_events.sh now includes:"
+echo "  - data/raw/filings/*/index.json -> extractor"
+echo "  - data/raw/filings/*/extracted.json -> ${DISPATCH_FUNCTION}"
+echo "Run scripts/deploy_8k_events.sh after this script to apply the bucket notification config."
 
 # --- 4. Sync monitor configs to S3 ---
 echo ""

--- a/src/modules/monitor/evaluator/collector.py
+++ b/src/modules/monitor/evaluator/collector.py
@@ -61,12 +61,25 @@ def _collect_filing(
     s3_path = event_data["s3_path"]
     ticker = event_data.get("ticker", config.tickers[0] if config.tickers else "?")
 
-    # Read the extracted.json from S3
-    try:
-        resp = _get_s3_client().get_object(Bucket=BUCKET, Key=s3_path)
-        extracted = json.loads(resp["Body"].read())
-    except Exception:
-        logger.exception("Failed to read extracted filing at %s", s3_path)
+    # Prefer extracted.json content. Some legacy dispatch paths pass analysis.json,
+    # which lacks filing text and would otherwise make the monitor a no-op.
+    extracted = None
+    loaded_key = None
+    candidate_keys = [s3_path]
+    if s3_path.endswith("/analysis.json"):
+        candidate_keys = [s3_path.replace("/analysis.json", "/extracted.json"), s3_path]
+
+    for key in candidate_keys:
+        try:
+            resp = _get_s3_client().get_object(Bucket=BUCKET, Key=key)
+            extracted = json.loads(resp["Body"].read())
+            loaded_key = key
+            break
+        except Exception:
+            logger.debug("Failed to read filing payload at %s", key)
+
+    if extracted is None or loaded_key is None:
+        logger.exception("Failed to read filing payload for %s", s3_path)
         return {"status": "unchanged", "source": f"filing:{s3_path}", "current_state": ""}
 
     # Build filing text from extracted data
@@ -74,7 +87,7 @@ def _collect_filing(
     if not filing_text.strip():
         return {
             "status": "unchanged",
-            "source": f"filing:{s3_path}",
+            "source": f"filing:{loaded_key}",
             "current_state": "Empty filing text",
         }
 
@@ -90,13 +103,13 @@ def _collect_filing(
         response = call_sonnet(system=system_prompt, user=user_prompt)
     except Exception:
         logger.exception("Sonnet call failed for monitor %s", config.id)
-        return {"status": "unchanged", "source": f"filing:{s3_path}", "current_state": ""}
+        return {"status": "unchanged", "source": f"filing:{loaded_key}", "current_state": ""}
 
     # Parse Sonnet response for significance
     significance = _parse_significance(response)
 
     return {
-        "source": f"filing:{s3_path}",
+        "source": f"filing:{loaded_key}",
         "current_state": response,
         "status": "updated",
         "delta_from_previous": _compute_delta(previous_state, response),

--- a/src/modules/monitor/evaluator/handler.py
+++ b/src/modules/monitor/evaluator/handler.py
@@ -6,6 +6,7 @@ Loads monitor configs from S3, runs collectors, writes snapshot artifacts.
 from __future__ import annotations
 
 import logging
+import os
 from datetime import datetime, timezone
 from typing import Any
 
@@ -19,7 +20,7 @@ from src.modules.monitor.evaluator.models import EvaluatorResult, MonitorConfig
 
 logger = logging.getLogger(__name__)
 
-BUCKET = "praxis-copilot"
+BUCKET = os.environ.get("S3_BUCKET", "praxis-copilot")
 CONFIG_PREFIX = "config/monitors/"
 
 

--- a/src/modules/monitor/evaluator/snapshot.py
+++ b/src/modules/monitor/evaluator/snapshot.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 import boto3
@@ -12,7 +13,7 @@ from .models import MonitorSnapshot
 
 logger = logging.getLogger(__name__)
 
-BUCKET = "praxis-copilot"
+BUCKET = os.environ.get("S3_BUCKET", "praxis-copilot")
 MONITORS_PREFIX = "data/monitors"
 
 

--- a/tests/test_monitor_filing_collector.py
+++ b/tests/test_monitor_filing_collector.py
@@ -1,0 +1,90 @@
+import json
+
+from src.modules.monitor.evaluator import collector
+from src.modules.monitor.evaluator.models import MonitorConfig
+
+
+class _FakeBody:
+    def __init__(self, payload: str):
+        self._payload = payload
+
+    def read(self):
+        return self._payload.encode("utf-8")
+
+
+class _FakeS3:
+    def __init__(self, objects: dict[str, dict]):
+        self.objects = objects
+
+    def get_object(self, Bucket, Key):
+        if Key not in self.objects:
+            raise KeyError(Key)
+        return {"Body": _FakeBody(json.dumps(self.objects[Key]))}
+
+
+def test_filing_collector_falls_back_from_analysis_to_extracted(monkeypatch):
+    analysis_key = "data/raw/8k/0001045810/0001/analysis.json"
+    extracted_key = "data/raw/8k/0001045810/0001/extracted.json"
+
+    fake_s3 = _FakeS3(
+        {
+            analysis_key: {"classification": "BUY", "magnitude": 0.8},
+            extracted_key: {
+                "form_type": "8-K",
+                "items": {"2.02": "Revenue and guidance were raised."},
+            },
+        }
+    )
+
+    monkeypatch.setattr(collector, "_get_s3_client", lambda: fake_s3)
+    monkeypatch.setattr(collector, "_load_thesis_context", lambda ticker: "")
+    monkeypatch.setattr(
+        collector,
+        "call_sonnet",
+        lambda system, user: "SIGNIFICANCE: high\nMaterial update detected.",
+    )
+
+    config = MonitorConfig(
+        id="nvda-filing-monitor",
+        type="filing",
+        tickers=["NVDA"],
+        description="Track material filing updates",
+        extract="Find material updates",
+        filing_types=["8-K"],
+    )
+
+    result = collector.collect(
+        config=config,
+        previous=None,
+        event_data={"s3_path": analysis_key, "ticker": "NVDA"},
+    )
+
+    assert result["status"] == "updated"
+    assert result["significance"] == "high"
+    assert result["source"] == f"filing:{extracted_key}"
+
+
+def test_filing_collector_returns_unchanged_when_text_is_unavailable(monkeypatch):
+    analysis_key = "data/raw/8k/0001045810/0001/analysis.json"
+    fake_s3 = _FakeS3({analysis_key: {"classification": "BUY", "magnitude": 0.8}})
+
+    monkeypatch.setattr(collector, "_get_s3_client", lambda: fake_s3)
+    monkeypatch.setattr(collector, "_load_thesis_context", lambda ticker: "")
+
+    config = MonitorConfig(
+        id="nvda-filing-monitor",
+        type="filing",
+        tickers=["NVDA"],
+        description="Track material filing updates",
+        extract="Find material updates",
+        filing_types=["8-K"],
+    )
+
+    result = collector.collect(
+        config=config,
+        previous=None,
+        event_data={"s3_path": analysis_key, "ticker": "NVDA"},
+    )
+
+    assert result["status"] == "unchanged"
+    assert result["current_state"] == "Empty filing text"

--- a/tests/test_monitor_handler_bucket.py
+++ b/tests/test_monitor_handler_bucket.py
@@ -1,0 +1,34 @@
+from src.modules.monitor.evaluator import handler
+
+
+class _FakeBody:
+    def __init__(self, text: str):
+        self._text = text
+
+    def read(self):
+        return self._text.encode("utf-8")
+
+
+class _FakePaginator:
+    def paginate(self, Bucket, Prefix):
+        assert Bucket == "test-bucket"
+        assert Prefix == "config/monitors/"
+        return [{"Contents": [{"Key": "config/monitors/sample.yaml"}]}]
+
+
+class _FakeS3:
+    def get_paginator(self, name):
+        assert name == "list_objects_v2"
+        return _FakePaginator()
+
+    def get_object(self, Bucket, Key):
+        assert Bucket == "test-bucket"
+        assert Key == "config/monitors/sample.yaml"
+        return {"Body": _FakeBody("id: sample\ntype: filing\ntickers: [AGM]\ndescription: d\nextract: e\n")}
+
+
+def test_load_monitor_configs_uses_configured_bucket(monkeypatch):
+    monkeypatch.setattr(handler, "BUCKET", "test-bucket")
+    configs = handler._load_monitor_configs(_FakeS3())
+    assert len(configs) == 1
+    assert configs[0].id == "sample"


### PR DESCRIPTION
## Summary
This PR fixes monitor routing/deploy correctness for the existing 8k + monitor flow, without taking on unrelated issues.

### What changed
- Fix filing monitor collector fallback behavior:
  - If dispatch event points to `analysis.json`, collector now prefers sibling `extracted.json` so monitor extraction still has filing text.
- Fix monitor evaluator bucket wiring:
  - `src/modules/monitor/evaluator/{handler,snapshot}.py` now respect `S3_BUCKET` env instead of hardcoded bucket name.
- Fix deploy wiring for unified filing path in `scripts/deploy_8k_events.sh`:
  - Add S3 notification `data/raw/filings/*/index.json -> extractor`
  - Add S3 notification `data/raw/filings/*/extracted.json -> dispatch`
- Harden deploy scripts:
  - `scripts/deploy_monitors.sh` now loads `.env.deploy`, safely builds env vars, and includes `ANTHROPIC_API_KEY` when present.
  - `scripts/deploy_8k_events.sh` includes monitor-evaluator invoke-permission setup attempt and logs warning if IAM edit is not allowed.

## Tests
Added targeted unit tests:
- `tests/test_monitor_filing_collector.py`
- `tests/test_monitor_handler_bucket.py`

Full suite result locally:
- `20 passed`

## Live validation performed
- Deployed 8k stack and monitor evaluator in AWS (us-east-2).
- Verified S3 notification configuration includes new unified filing routes.
- Verified dispatch emits event records for `data/raw/filings/.../extracted.json` and matches filing monitors.
- Verified monitor snapshot artifacts are written under `data/monitors/{monitor_id}/` after end-to-end synthetic filing event.
