### PR TITLE
Fix upload progress count showing X > Y in uploaded X/Y files

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -31,6 +31,7 @@ from cli.s3 import (
     key_exists,
     list_prefix,
     upload_directory,
+    upload_file,
 )
 
 
@@ -648,7 +649,11 @@ def research_sync(tickers: tuple[str, ...]):
         s3_prefix = f"data/research/{ticker}"
         click.echo(f"\nUploading to s3://{BUCKET}/{s3_prefix}/ ...")
 
-        uploaded = upload_directory(s3, local_dir, s3_prefix)
+        uploaded = []
+        for rel in found:
+            s3_key = f"{s3_prefix}/{rel}"
+            upload_file(s3, local_dir / rel, s3_key)
+            uploaded.append(s3_key)
         click.echo(f"Synced {len(uploaded)} file(s):")
         for key in uploaded:
             click.echo(f"  {key}")


### PR DESCRIPTION
## Summary
- `research_sync` used `upload_directory()` which uploads **all** files in the workspace, but compared the count against `found` which filters out `data/`, `macro/`, `CLAUDE.md`, and `.mcp.json`. This caused `uploaded` to exceed `found`, producing confusing "uploaded X/Y files" messages where X > Y.
- Replaced the `upload_directory()` call with a direct loop over the filtered `found` list using `upload_file()`, ensuring both counts always match.

Closes #35

## Test plan
- [ ] Run `praxis research sync` on a workspace containing skipped files (e.g., `data/`, `CLAUDE.md`) and verify the progress message shows X <= Y.
- [ ] Verify that all expected artifacts are still uploaded to S3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)