### PR TITLE
Add interactive pipeline browser

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -27,6 +27,7 @@ from cli.macro import (
 )
 from cli.models import TickerRegistry, TickerRegistryEntry, UniverseConfig
 from cli.monitors import monitor
+from cli.pipeline_interactive import interactive_pipeline_day_view, trace_payload
 from cli.pipeline_status import (
     build_pipeline_trace,
     collect_pipeline_items,
@@ -537,6 +538,12 @@ def events(ticker: str, limit: int):
     is_flag=True,
     help="For ITEM_ID mode, print full derived JSON outputs (extracted/screening/analysis)",
 )
+@click.option(
+    "-i",
+    "--interactive",
+    is_flag=True,
+    help="Interactive day browser to inspect filings/releases in a pager",
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit JSON output")
 @click.option("--logs", is_flag=True, help="Include CloudWatch logs (best effort)")
 @click.option("--log-lines", type=click.IntRange(1, 200), default=20, show_default=True, help="Max lines per Lambda")
@@ -547,6 +554,7 @@ def pipeline(
     source: str,
     stuck_minutes: int,
     verbose: bool,
+    interactive: bool,
     as_json: bool,
     logs: bool,
     log_lines: int,
@@ -565,6 +573,9 @@ def pipeline(
     """
     s3 = get_s3_client()
 
+    if interactive and (item_id or as_json):
+        raise click.UsageError("--interactive is supported only for day view (without ITEM_ID and --json).")
+
     if item_id:
         matches = find_prefixes_by_item_id(s3, item_id=item_id, source=source)
         if not matches:
@@ -575,34 +586,7 @@ def pipeline(
             return
 
         traces = [build_pipeline_trace(s3, source_type=src_type, key_prefix=prefix) for src_type, prefix in matches]
-        traces_payload = [
-            {
-                "source_type": trace.source_type,
-                "key_prefix": trace.key_prefix,
-                "item_id": trace.item_id,
-                "ticker": trace.ticker,
-                "cik": trace.cik,
-                "form_type": trace.form_type,
-                "source": trace.source,
-                "stage": trace.stage,
-                "files": trace.files,
-                "arrived_at": trace.arrived_at,
-                "extracted_at": trace.extracted_at,
-                "analyzed_at": trace.analyzed_at,
-                "screening_at": trace.screening_at,
-                "alert_sent_at": trace.alert_sent_at,
-                "analysis": {
-                    "classification": trace.analysis_classification,
-                    "magnitude": trace.analysis_magnitude,
-                    "summary": trace.analysis_summary,
-                },
-                "extracted": {
-                    "total_chars": trace.extracted_total_chars,
-                    "items": trace.extracted_items,
-                },
-            }
-            for trace in traces
-        ]
+        traces_payload = [trace_payload(trace) for trace in traces]
 
         logs_payload = []
         if logs:
@@ -676,6 +660,10 @@ def pipeline(
         stuck_minutes=stuck_minutes,
     )
     summary = summarize_pipeline_items(items)
+
+    if interactive:
+        interactive_pipeline_day_view(s3_client=s3, items=items, target_day=target_day, source=source)
+        return
 
     if as_json:
         payload = {
@@ -820,6 +808,7 @@ def _print_trace_file_contents(s3_client, key_prefix: str, files: list[str]) -> 
 
     if printed == 0:
         click.echo("\n(no derived JSON artifacts found)")
+
 
 # ---------------------------------------------------------------------------
 # praxis research

--- a/src/cli/pipeline_interactive.py
+++ b/src/cli/pipeline_interactive.py
@@ -1,0 +1,249 @@
+"""Interactive helpers for praxis pipeline day browsing."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import date
+from shutil import get_terminal_size
+
+import click
+
+from cli.pipeline_status import PipelineItem, PipelineTrace, build_pipeline_trace
+from cli.s3 import download_file
+
+
+def trace_payload(trace: PipelineTrace) -> dict:
+    return {
+        "source_type": trace.source_type,
+        "key_prefix": trace.key_prefix,
+        "item_id": trace.item_id,
+        "ticker": trace.ticker,
+        "cik": trace.cik,
+        "form_type": trace.form_type,
+        "source": trace.source,
+        "stage": trace.stage,
+        "files": trace.files,
+        "arrived_at": trace.arrived_at,
+        "extracted_at": trace.extracted_at,
+        "analyzed_at": trace.analyzed_at,
+        "screening_at": trace.screening_at,
+        "alert_sent_at": trace.alert_sent_at,
+        "analysis": {
+            "classification": trace.analysis_classification,
+            "magnitude": trace.analysis_magnitude,
+            "summary": trace.analysis_summary,
+        },
+        "extracted": {
+            "total_chars": trace.extracted_total_chars,
+            "items": trace.extracted_items,
+        },
+    }
+
+
+def build_interactive_trace_text(s3_client, trace: PipelineTrace) -> str:
+    payload = trace_payload(trace)
+    lines = [
+        f"Pipeline trace for id={trace.item_id}",
+        "=" * 80,
+        json.dumps(payload, indent=2),
+        "",
+        "Artifacts:",
+    ]
+
+    for name in ("index.json", "extracted.json", "screening.json", "analysis.json"):
+        if name not in trace.files:
+            continue
+        key = f"{trace.key_prefix}/{name}"
+        lines.append("")
+        lines.append("-" * 80)
+        lines.append(name)
+        lines.append("-" * 80)
+        try:
+            body = download_file(s3_client, key).decode("utf-8", errors="replace")
+            lines.append(body.rstrip())
+        except Exception as exc:
+            lines.append(f"(unable to read {key}: {exc})")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def open_text_in_pager(text: str) -> None:
+    less_bin = shutil.which("less")
+    if less_bin:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False, suffix=".txt") as tmp:
+            tmp.write(text)
+            tmp_path = tmp.name
+        try:
+            subprocess.run([less_bin, "-R", tmp_path], check=False)
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+        return
+
+    click.echo_via_pager(text)
+
+
+def _truncate(value: str, width: int) -> str:
+    if width <= 0:
+        return ""
+    if len(value) <= width:
+        return value
+    if width <= 3:
+        return value[:width]
+    return value[: width - 3] + "..."
+
+
+def _format_selected_details(item: PipelineItem) -> list[str]:
+    return [
+        f"stage: {item.stage}",
+        f"type: {item.source_type}",
+        f"ticker: {item.ticker or '-'}",
+        f"item_id: {item.item_id}",
+        f"age_minutes: {item.age_minutes}",
+        f"form: {item.form_type or '-'}",
+        f"source: {item.source or '-'}",
+        f"cik: {item.cik or '-'}",
+        f"prefix: {item.key_prefix}",
+    ]
+
+
+def _viewport_bounds(total_items: int, selected_index: int, window_size: int) -> tuple[int, int]:
+    if total_items <= 0:
+        return 0, 0
+    window_size = max(1, window_size)
+    start = max(0, min(selected_index - (window_size // 2), total_items - window_size))
+    end = min(total_items, start + window_size)
+    return start, end
+
+
+def _read_navigation_key() -> str:
+    ch = click.getchar()
+    if ch == "\x1b":
+        next_ch = click.getchar()
+        if next_ch != "[":
+            return "escape"
+        final_ch = click.getchar()
+        if final_ch in {"5", "6"}:
+            tail = click.getchar()
+            if tail == "~":
+                return {"5": "page_up", "6": "page_down"}[final_ch]
+            return "escape"
+        return {
+            "A": "up",
+            "B": "down",
+        }.get(final_ch, "escape")
+    if ch in {"k", "K"}:
+        return "up"
+    if ch in {"j", "J"}:
+        return "down"
+    if ch in {"g"}:
+        return "home"
+    if ch in {"G"}:
+        return "end"
+    if ch in {"q", "Q"}:
+        return "quit"
+    if ch in {"\r", "\n"}:
+        return "open"
+    if ch == " ":
+        return "page_down"
+    return "unknown"
+
+
+def _move_selection(selected_index: int, key: str, total_items: int, page_size: int) -> int:
+    if total_items <= 0:
+        return 0
+
+    max_index = total_items - 1
+    if key == "up":
+        return max(0, selected_index - 1)
+    if key == "down":
+        return min(max_index, selected_index + 1)
+    if key == "page_up":
+        return max(0, selected_index - max(1, page_size))
+    if key == "page_down":
+        return min(max_index, selected_index + max(1, page_size))
+    if key == "home":
+        return 0
+    if key == "end":
+        return max_index
+    return selected_index
+
+
+def _render_day_view(items: list[PipelineItem], target_day: date, source: str, selected_index: int) -> str:
+    terminal_size = get_terminal_size((120, 40))
+    width = max(80, terminal_size.columns)
+    height = max(24, terminal_size.lines)
+    list_height = max(5, height - 18)
+    start, end = _viewport_bounds(len(items), selected_index, list_height)
+
+    lines = [
+        f"Praxis Pipeline Interactive  {target_day.isoformat()} ET  source={source}",
+        "Navigate: up/down arrows or j/k, Enter=open, g/G=top/bottom, Space/PgDn, q=quit",
+        "",
+    ]
+
+    if not items:
+        lines.append("No filings/releases found for this day and source.")
+        return "\n".join(lines)
+
+    header = f"{' ':2} {'stage':13} {'type':14} {'ticker':8} {'item_id':28} {'age_m':>6}"
+    lines.append(_truncate(header, width))
+    lines.append("-" * min(width, len(header)))
+
+    for idx in range(start, end):
+        item = items[idx]
+        marker = ">" if idx == selected_index else " "
+        row = (
+            f"{marker} "
+            f"{item.stage[:13]:13} "
+            f"{item.source_type[:14]:14} "
+            f"{(item.ticker or '-')[:8]:8} "
+            f"{item.item_id[:28]:28} "
+            f"{item.age_minutes:>6}"
+        )
+        lines.append(_truncate(row, width))
+
+    lines.append("")
+    lines.append("-" * min(width, 80))
+    lines.extend(_truncate(line, width) for line in _format_selected_details(items[selected_index]))
+    if start > 0 or end < len(items):
+        lines.append("")
+        lines.append(_truncate(f"Showing {start + 1}-{end} of {len(items)}", width))
+
+    return "\n".join(lines)
+
+
+def interactive_pipeline_day_view(s3_client, items: list[PipelineItem], target_day: date, source: str) -> None:
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        raise click.ClickException("Interactive mode requires a TTY (run from a terminal).")
+
+    if not items:
+        click.clear()
+        click.echo(_render_day_view(items, target_day, source, selected_index=0))
+        click.pause(info="Press any key to exit")
+        return
+
+    selected_index = 0
+    while True:
+        terminal_size = get_terminal_size((120, 40))
+        page_size = max(1, terminal_size.lines - 18)
+        click.clear()
+        click.echo(_render_day_view(items, target_day, source, selected_index))
+        key = _read_navigation_key()
+        if key == "quit":
+            return
+        if key == "open":
+            item = items[selected_index]
+            trace = build_pipeline_trace(s3_client, source_type=item.source_type, key_prefix=item.key_prefix)
+            open_text_in_pager(build_interactive_trace_text(s3_client, trace))
+            continue
+        if key == "unknown":
+            continue
+        selected_index = _move_selection(selected_index, key, len(items), page_size=page_size)

--- a/tests/test_cli_pipeline_interactive.py
+++ b/tests/test_cli_pipeline_interactive.py
@@ -1,0 +1,107 @@
+from datetime import date, datetime, timezone
+
+from src.cli import pipeline_interactive as pi
+from src.cli.pipeline_status import PipelineItem
+from src.cli.pipeline_status import PipelineTrace
+
+
+def _sample_trace() -> PipelineTrace:
+    return PipelineTrace(
+        source_type="filings",
+        key_prefix="data/raw/filings/0001/a1",
+        item_id="a1",
+        ticker="NVDA",
+        cik="0001045810",
+        form_type="8-K",
+        source="sec",
+        files=["index.json", "extracted.json", "analysis.json"],
+        stage="analyzed",
+        arrived_at="2026-03-05T14:00:00+00:00",
+        extracted_at="2026-03-05T14:01:00+00:00",
+        analyzed_at="2026-03-05T14:02:00+00:00",
+        screening_at="",
+        alert_sent_at="",
+        analysis_classification="BUY",
+        analysis_magnitude=0.9,
+        analysis_summary="Raised guidance",
+        extracted_total_chars=1200,
+        extracted_items=["2.02"],
+    )
+
+
+def test_trace_payload_contains_expected_fields():
+    trace = _sample_trace()
+    payload = pi.trace_payload(trace)
+
+    assert payload["item_id"] == "a1"
+    assert payload["analysis"]["classification"] == "BUY"
+    assert payload["extracted"]["items"] == ["2.02"]
+
+
+def test_build_interactive_trace_text_includes_artifacts(monkeypatch):
+    trace = _sample_trace()
+
+    payloads = {
+        "data/raw/filings/0001/a1/index.json": b'{"ticker":"NVDA"}',
+        "data/raw/filings/0001/a1/extracted.json": b'{"total_chars":1200}',
+        "data/raw/filings/0001/a1/analysis.json": b'{"classification":"BUY"}',
+    }
+
+    monkeypatch.setattr(pi, "download_file", lambda _s3, key: payloads[key])
+
+    text = pi.build_interactive_trace_text(object(), trace)
+
+    assert "Pipeline trace for id=a1" in text
+    assert '"item_id": "a1"' in text
+    assert "Artifacts:" in text
+    assert "index.json" in text
+    assert '{"classification":"BUY"}' in text
+
+
+def test_move_selection_respects_bounds_and_paging():
+    assert pi._move_selection(0, "up", total_items=5, page_size=3) == 0
+    assert pi._move_selection(0, "down", total_items=5, page_size=3) == 1
+    assert pi._move_selection(1, "page_down", total_items=5, page_size=3) == 4
+    assert pi._move_selection(4, "page_up", total_items=5, page_size=3) == 1
+    assert pi._move_selection(2, "home", total_items=5, page_size=3) == 0
+    assert pi._move_selection(2, "end", total_items=5, page_size=3) == 4
+
+
+def test_render_day_view_shows_selection_and_details(monkeypatch):
+    monkeypatch.setattr(pi, "get_terminal_size", lambda fallback: __import__("os").terminal_size((100, 24)))
+
+    items = [
+        PipelineItem(
+            source_type="filings",
+            key_prefix="data/raw/filings/0001/a1",
+            ticker="NVDA",
+            cik="0001045810",
+            form_type="8-K",
+            source="sec",
+            item_id="a1",
+            arrived_at=datetime(2026, 3, 5, 14, 0, tzinfo=timezone.utc),
+            stage="analyzed",
+            alert_sent_at=None,
+            age_minutes=12,
+        ),
+        PipelineItem(
+            source_type="press_releases",
+            key_prefix="data/raw/press_releases/gnw/NVDA/r1",
+            ticker="NVDA",
+            cik="0001045810",
+            form_type="",
+            source="gnw",
+            item_id="r1",
+            arrived_at=datetime(2026, 3, 5, 14, 5, tzinfo=timezone.utc),
+            stage="screened_out",
+            alert_sent_at=None,
+            age_minutes=7,
+        ),
+    ]
+
+    text = pi._render_day_view(items, date(2026, 3, 5), "all", selected_index=1)
+
+    assert "Navigate: up/down arrows or j/k" in text
+    assert "> screened_out" in text
+    assert "item_id: r1" in text
+    assert "prefix: data/raw/press_releases/gnw/NVDA/r1" in text


### PR DESCRIPTION
## Summary
- add `praxis pipeline -i` day-view mode for interactive browsing
- support keyboard navigation with arrows or `j/k`, paging, and `Enter` to open the selected filing in `less`
- show a focused details pane for the selected filing and keep full trace/artifact inspection in the pager

## Testing
- `PYTHONPATH=src pytest -q tests/test_cli_pipeline_status.py tests/test_cli_pipeline_interactive.py`