### PR TITLE
Optimize praxis status S3 scans

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -56,6 +56,55 @@ def cli():
 cli.add_command(monitor)
 
 
+def _extract_tickers_from_monitor(monitor_data: dict) -> set[str]:
+    """Return the set of tickers referenced by a monitor config."""
+    tickers = set()
+    # New schema: tickers list
+    for t in monitor_data.get("tickers", []):
+        if isinstance(t, str) and t.strip():
+            tickers.add(t.strip().upper())
+    # Legacy schema: listen entries like "TICKER:event"
+    for entry in monitor_data.get("listen", []):
+        if not isinstance(entry, str) or ":" not in entry:
+            continue
+        ticker = entry.split(":", 1)[0].strip().upper()
+        if ticker:
+            tickers.add(ticker)
+    return tickers
+
+
+def _build_monitor_counts(s3_client) -> dict[str, int]:
+    """Build a per-ticker monitor count with a single monitor prefix scan."""
+    monitor_counts: dict[str, int] = {}
+    for monitor_key in list_prefix(s3_client, "config/monitors/"):
+        try:
+            monitor_data = yaml.safe_load(download_file(s3_client, monitor_key)) or {}
+        except Exception:
+            continue
+
+        for ticker in _extract_tickers_from_monitor(monitor_data):
+            monitor_counts[ticker] = monitor_counts.get(ticker, 0) + 1
+
+    return monitor_counts
+
+
+def _get_research_status(s3_client, ticker: str) -> tuple[bool, int]:
+    """Return memo presence and ingested data file count for a ticker."""
+    prefix = f"data/research/{ticker}/"
+    keys = list_prefix(s3_client, prefix)
+    has_memo = False
+    data_count = 0
+
+    for key in keys:
+        relative = key[len(prefix):]
+        if relative == "memo.yaml":
+            has_memo = True
+        elif relative.startswith("data/"):
+            data_count += 1
+
+    return has_memo, data_count
+
+
 # ---------------------------------------------------------------------------
 # praxis config sync
 # ---------------------------------------------------------------------------
@@ -416,43 +465,20 @@ def status():
     try:
         s3 = get_s3_client()
         use_s3 = True
+        monitor_counts = _build_monitor_counts(s3)
     except SystemExit:
         click.echo("(Could not connect to AWS — showing local status only)\n")
         use_s3 = False
+        monitor_counts = {}
 
     for ticker in sorted(universe_cfg.tickers):
         parts = [ticker]
 
         if use_s3:
-            # Check for memo
-            has_memo = key_exists(s3, f"data/research/{ticker}/memo.yaml")
+            has_memo, data_count = _get_research_status(s3, ticker)
             parts.append("memo:yes" if has_memo else "memo:no")
-
-            # Check for ingested data
-            data_keys = list_prefix(s3, f"data/research/{ticker}/data/")
-            parts.append(f"data:{len(data_keys)} files" if data_keys else "data:none")
-
-            # Count monitors
-            monitor_keys = list_prefix(s3, f"config/monitors/")
-            monitor_count = 0
-            for mk in monitor_keys:
-                try:
-                    content = download_file(s3, mk)
-                    mdata = yaml.safe_load(content)
-                    # New schema: check tickers list
-                    tickers_list = mdata.get("tickers", [])
-                    if ticker in tickers_list:
-                        monitor_count += 1
-                        continue
-                    # Legacy schema: check listen keys
-                    listen = mdata.get("listen", [])
-                    for entry in listen:
-                        if isinstance(entry, str) and entry.startswith(f"{ticker}:"):
-                            monitor_count += 1
-                            break
-                except Exception:
-                    pass
-            parts.append(f"monitors:{monitor_count}")
+            parts.append(f"data:{data_count} files" if data_count else "data:none")
+            parts.append(f"monitors:{monitor_counts.get(ticker, 0)}")
 
         click.echo("  ".join(parts))
 

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from cli.main import cli
+
+
+def test_status_reuses_monitor_scan_and_research_listing(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "universe.yaml").write_text(
+        yaml.safe_dump({"tickers": ["AAPL", "MSFT"]}),
+        encoding="utf-8",
+    )
+
+    calls: list[str] = []
+    monitor_docs = {
+        "config/monitors/aapl.yaml": {
+            "tickers": ["AAPL"],
+            "listen": ["AAPL:filing", "AAPL:search", "MSFT:search"],
+        },
+        "config/monitors/msft.yaml": {
+            "tickers": ["MSFT"],
+            "listen": ["MSFT:filing"],
+        },
+    }
+    research_keys = {
+        "data/research/AAPL/": [
+            "data/research/AAPL/memo.yaml",
+            "data/research/AAPL/data/financials.json",
+            "data/research/AAPL/data/transcript.json",
+        ],
+        "data/research/MSFT/": [
+            "data/research/MSFT/data/financials.json",
+        ],
+    }
+
+    def fake_list_prefix(_s3, prefix):
+        calls.append(prefix)
+        if prefix == "config/monitors/":
+            return list(monitor_docs)
+        return research_keys.get(prefix, [])
+
+    def fake_download_file(_s3, key):
+        return yaml.safe_dump(monitor_docs[key]).encode("utf-8")
+
+    monkeypatch.setattr("cli.main.get_config_dir", lambda: config_dir)
+    monkeypatch.setattr("cli.main.get_s3_client", lambda: object())
+    monkeypatch.setattr("cli.main.list_prefix", fake_list_prefix)
+    monkeypatch.setattr("cli.main.download_file", fake_download_file)
+
+    result = CliRunner().invoke(cli, ["status"])
+
+    assert result.exit_code == 0
+    assert "AAPL  memo:yes  data:2 files  monitors:1" in result.output
+    assert "MSFT  memo:no  data:1 files  monitors:2" in result.output
+    # Verify monitors were scanned only once (not per-ticker)
+    assert calls.count("config/monitors/") == 1
+    assert calls.count("data/research/AAPL/") == 1
+    assert calls.count("data/research/MSFT/") == 1


### PR DESCRIPTION
## Summary
- scan `config/monitors/` once and build a per-ticker monitor count map
- reuse a single `data/research/{ticker}/` listing to determine memo presence and ingested data counts
- add a focused CLI regression test for the optimized status path

## Verification
- Verified behavior under the repo `.venv` with a direct Click runner check matching the new test setup

Closes #39.