### PR TITLE
Zone-transition valuation alerts

### DIFF
--- a/scripts/deploy_manage.sh
+++ b/scripts/deploy_manage.sh
@@ -14,7 +14,7 @@ if [[ -f "${DEPLOY_ENV_FILE}" ]]; then
   set +a
 fi
 
-REGION="${REGION:-us-east-2}"
+REGION="${REGION:-us-east-1}"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 BUCKET="${S3_BUCKET:-praxis-copilot}"
 FUNCTION_NAME="${MANAGE_FUNCTION:-praxis-manage-intraday}"

--- a/src/modules/manage/intraday.py
+++ b/src/modules/manage/intraday.py
@@ -257,6 +257,6 @@ def run_all_checks(
     alerts.extend(check_volume_velocity(price_data, effective, ticker_state))
 
     if anchors:
-        alerts.extend(check_valuation_anchors(price_data, anchors))
+        alerts.extend(check_valuation_anchors(price_data, anchors, ticker_state))
 
     return alerts

--- a/src/modules/manage/models.py
+++ b/src/modules/manage/models.py
@@ -89,6 +89,11 @@ class IntradayTickerState(BaseModel):
     # Move-from-close: which threshold bands have fired (e.g. [1, 2] = 5%, 10%)
     close_bands_fired: list[int] = Field(default_factory=list)
 
+    # Valuation zone tracking for transition-based alerts.
+    # Zones: "below_stop", "deep_value", "entry_range", "fair_value",
+    #         "exit_range", "overvalued", "above_target", or None (unknown)
+    valuation_zone: str | None = None
+
 
 class IntradayState(BaseModel):
     """Persisted intraday state across all tickers.  Resets daily."""

--- a/src/modules/manage/price.py
+++ b/src/modules/manage/price.py
@@ -6,7 +6,11 @@ import os
 from datetime import datetime, timezone
 
 import requests
-import yfinance as yf
+
+try:
+    import yfinance as yf
+except ImportError:
+    yf = None  # Lambda deployment doesn't include yfinance
 
 from .models import PriceData
 
@@ -122,6 +126,8 @@ def _fetch_price_data_eodhd(ticker: str, api_key: str) -> PriceData:
 
 def _fetch_price_data_yfinance(ticker: str) -> PriceData:
     """Fallback quote source when EODHD is unavailable."""
+    if yf is None:
+        raise ImportError("yfinance is not installed; EODHD_API_KEY must be set")
     yf_ticker = yf.Ticker(ticker)
     hist = yf_ticker.history(period="1mo")
     if hist.empty:

--- a/src/modules/manage/thresholds.py
+++ b/src/modules/manage/thresholds.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from typing import Any
 
 import boto3
 import yaml
@@ -11,6 +12,7 @@ from botocore.exceptions import ClientError
 from .models import (
     Alert,
     AlertType,
+    IntradayTickerState,
     ManageConfig,
     PriceData,
     Severity,
@@ -48,13 +50,36 @@ def load_valuation_anchors(s3_client: boto3.client, ticker: str) -> ValuationAnc
     entry_range = valuation.get("entry_range", {})
     exit_range = valuation.get("exit_range", {})
 
+    # Handle both dict {"low": x, "high": y} and list [low, high] formats
+    def _safe_float(v: Any) -> float | None:
+        try:
+            return float(v) if v is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    if isinstance(entry_range, list) and len(entry_range) >= 2:
+        entry_low, entry_high = _safe_float(entry_range[0]), _safe_float(entry_range[1])
+    elif isinstance(entry_range, dict):
+        entry_low = _safe_float(entry_range.get("low"))
+        entry_high = _safe_float(entry_range.get("high"))
+    else:
+        entry_low, entry_high = None, None
+
+    if isinstance(exit_range, list) and len(exit_range) >= 2:
+        exit_low, exit_high = _safe_float(exit_range[0]), _safe_float(exit_range[1])
+    elif isinstance(exit_range, dict):
+        exit_low = _safe_float(exit_range.get("low"))
+        exit_high = _safe_float(exit_range.get("high"))
+    else:
+        exit_low, exit_high = None, None
+
     return ValuationAnchors(
         fair_value_estimate=valuation.get("fair_value_estimate"),
-        entry_price=entry_range.get("low") if isinstance(entry_range, dict) else None,
-        entry_range_low=entry_range.get("low") if isinstance(entry_range, dict) else None,
-        entry_range_high=entry_range.get("high") if isinstance(entry_range, dict) else None,
-        exit_range_low=exit_range.get("low") if isinstance(exit_range, dict) else None,
-        exit_range_high=exit_range.get("high") if isinstance(exit_range, dict) else None,
+        entry_price=entry_low,
+        entry_range_low=entry_low,
+        entry_range_high=entry_high,
+        exit_range_low=exit_low,
+        exit_range_high=exit_high,
         stop_loss=valuation.get("stop_loss"),
         target_price=valuation.get("target_price"),
     )
@@ -86,68 +111,107 @@ def load_manage_config(s3_client: boto3.client) -> tuple[ManageConfig, dict]:
     }), overrides
 
 
+def _classify_valuation_zone(
+    price: float,
+    anchors: ValuationAnchors,
+) -> str:
+    """Classify which valuation zone the current price falls into.
+
+    Zones (checked in order from lowest to highest):
+      below_stop  – price ≤ stop_loss
+      deep_value  – price ≤ entry_range_low
+      entry_range – entry_range_low < price ≤ entry_range_high
+      fair_value  – between entry_range_high and exit_range_low
+      exit_range  – exit_range_low ≤ price < exit_range_high
+      overvalued  – price ≥ exit_range_high
+      above_target – price ≥ target_price (if set and above exit_range_high)
+
+    When boundaries are missing we collapse adjacent zones.
+    """
+    if anchors.stop_loss is not None and price <= anchors.stop_loss:
+        return "below_stop"
+
+    target = anchors.target_price or anchors.fair_value_estimate
+    entry_low = anchors.entry_range_low or anchors.entry_price
+
+    if entry_low is not None and price <= entry_low:
+        return "deep_value"
+
+    if anchors.entry_range_high is not None and price <= anchors.entry_range_high:
+        return "entry_range"
+
+    if anchors.exit_range_low is not None and price < anchors.exit_range_low:
+        return "fair_value"
+
+    if anchors.exit_range_high is not None and price < anchors.exit_range_high:
+        return "exit_range"
+
+    if target is not None and price >= target:
+        return "above_target"
+
+    if anchors.exit_range_high is not None and price >= anchors.exit_range_high:
+        return "overvalued"
+
+    return "fair_value"
+
+
+# Map zone transitions to the alert type that should fire
+_ZONE_ALERT_MAP: dict[str, AlertType] = {
+    "below_stop": AlertType.STOP_LOSS_BREACH,
+    "deep_value": AlertType.ENTRY_OPPORTUNITY,
+    "entry_range": AlertType.ENTRY_OPPORTUNITY,
+    "exit_range": AlertType.EXIT_SIGNAL,
+    "overvalued": AlertType.EXIT_SIGNAL,
+    "above_target": AlertType.TARGET_REACHED,
+}
+
+_ZONE_SEVERITY: dict[str, Severity] = {
+    "below_stop": Severity.CRITICAL,
+    "deep_value": Severity.HIGH,
+    "entry_range": Severity.MEDIUM,
+    "fair_value": Severity.LOW,
+    "exit_range": Severity.MEDIUM,
+    "overvalued": Severity.HIGH,
+    "above_target": Severity.HIGH,
+}
+
+
 def check_valuation_anchors(
     price_data: PriceData,
     anchors: ValuationAnchors,
+    ticker_state: IntradayTickerState,
 ) -> list[Alert]:
-    """Check price against valuation anchors (stop loss, target, entry/exit)."""
+    """Alert only on zone transitions — fires once per boundary crossing."""
     alerts: list[Alert] = []
     now = datetime.now(timezone.utc)
 
-    # Stop loss breach
-    if anchors.stop_loss is not None and price_data.price <= anchors.stop_loss:
-        alerts.append(Alert(
-            ticker=price_data.ticker,
-            timestamp=now,
-            alert_type=AlertType.STOP_LOSS_BREACH,
-            severity=Severity.CRITICAL,
-            details={
-                "price": price_data.price,
-                "stop_loss": anchors.stop_loss,
-            },
-        ))
+    new_zone = _classify_valuation_zone(price_data.price, anchors)
+    old_zone = ticker_state.valuation_zone
 
-    # Target price reached
-    target = anchors.target_price or anchors.fair_value_estimate
-    if target is not None and price_data.price >= target:
-        alerts.append(Alert(
-            ticker=price_data.ticker,
-            timestamp=now,
-            alert_type=AlertType.TARGET_REACHED,
-            severity=Severity.HIGH,
-            details={
-                "price": price_data.price,
-                "target_price": target,
-            },
-        ))
+    # Update state
+    ticker_state.valuation_zone = new_zone
 
-    # Entry opportunity (price drops into or below entry range)
-    entry_low = anchors.entry_range_low or anchors.entry_price
-    if entry_low is not None and price_data.price <= entry_low:
-        alerts.append(Alert(
-            ticker=price_data.ticker,
-            timestamp=now,
-            alert_type=AlertType.ENTRY_OPPORTUNITY,
-            severity=Severity.HIGH,
-            details={
-                "price": price_data.price,
-                "entry_range_low": entry_low,
-                "entry_range_high": anchors.entry_range_high,
-            },
-        ))
+    # First observation or no change — no alert
+    if old_zone is None or old_zone == new_zone:
+        return alerts
 
-    # Exit signal (price moves above exit range)
-    if anchors.exit_range_high is not None and price_data.price >= anchors.exit_range_high:
-        alerts.append(Alert(
-            ticker=price_data.ticker,
-            timestamp=now,
-            alert_type=AlertType.EXIT_SIGNAL,
-            severity=Severity.HIGH,
-            details={
-                "price": price_data.price,
-                "exit_range_high": anchors.exit_range_high,
-            },
-        ))
+    alert_type = _ZONE_ALERT_MAP.get(new_zone)
+    if alert_type is None:
+        # Transitioning back to fair_value — no alert needed
+        return alerts
+
+    severity = _ZONE_SEVERITY.get(new_zone, Severity.MEDIUM)
+    alerts.append(Alert(
+        ticker=price_data.ticker,
+        timestamp=now,
+        alert_type=alert_type,
+        severity=severity,
+        details={
+            "price": price_data.price,
+            "from_zone": old_zone,
+            "to_zone": new_zone,
+        },
+    ))
 
     return alerts
 
@@ -203,6 +267,8 @@ def check_thresholds(
         ))
 
     if anchors:
-        alerts.extend(check_valuation_anchors(price_data, anchors))
+        # CLI one-shot: use a fresh state so all zone alerts fire once
+        tmp_state = IntradayTickerState(valuation_zone="fair_value")
+        alerts.extend(check_valuation_anchors(price_data, anchors, tmp_state))
 
     return alerts


### PR DESCRIPTION
## Summary
- Valuation anchor alerts now fire only on zone transitions (e.g. fair_value -> overvalued) instead of every 15-min cycle
- Zones: below_stop, deep_value, entry_range, fair_value, exit_range, overvalued, above_target
- Fixed parsing of list-format entry/exit ranges and null values in memo.yaml
- Made yfinance import lazy so Lambda doesn't need the 184MB dependency
- Fixed deploy script default region to us-east-1

## Test plan
- [x] 8 existing intraday tests pass
- [x] Lambda run 1 (fresh state): 49 alerts, 0 errors - zones seeded silently
- [x] Lambda run 2 (same prices): 3 alerts - no duplicate valuation alerts

Generated with Claude Code