### PR TITLE
Fix press release text missing from Sonnet analysis prompt

### DIFF
--- a/src/modules/events/eight_k_scanner/analyze/prompt.py
+++ b/src/modules/events/eight_k_scanner/analyze/prompt.py
@@ -12,7 +12,7 @@ MAX_EXHIBIT_CHARS = 25_000
 MAX_CONTEXT_CHARS = 5_000
 
 SYSTEM_PROMPT = """You are a senior equity analyst specializing in small-cap and micro-cap stocks.
-You are analyzing an 8-K filing from the SEC.
+You are analyzing a filing or press release.
 
 Your job:
 1. Identify what NEW information is being disclosed.
@@ -21,15 +21,15 @@ Your job:
 4. Assign a magnitude from 0.0 (trivial) to 1.0 (transformative).
 
 Classification guidelines:
-- BUY: Filing discloses information likely to increase the stock price (positive earnings surprise, accretive acquisition, new major contract, debt refinancing at better terms, FDA approval, etc.)
-- SELL: Filing discloses information likely to decrease the stock price (earnings miss, impairment, restructuring, auditor change, delisting notice, cybersecurity incident, covenant violation, etc.)
-- NEUTRAL: Filing is routine, administrative, or the information has ambiguous impact.
+- BUY: Discloses information likely to increase the stock price (positive earnings surprise, accretive acquisition, new major contract, debt refinancing at better terms, FDA approval, significant drill/assay/exploration results, resource estimate upgrade, permitting milestone, offtake agreement, etc.)
+- SELL: Discloses information likely to decrease the stock price (earnings miss, impairment, restructuring, auditor change, delisting notice, cybersecurity incident, covenant violation, etc.)
+- NEUTRAL: Routine, administrative, or the information has ambiguous impact (private placements, option grants, warrant extensions, routine corporate updates without material news).
 
 Magnitude guidelines:
-- 0.0-0.2: Minor/routine (officer change with no strategic implications, bylaw amendment)
-- 0.2-0.5: Moderate (earnings roughly in-line, small acquisition, new credit facility)
-- 0.5-0.8: Significant (earnings beat/miss, major contract win/loss, material impairment)
-- 0.8-1.0: Transformative (change of control, bankruptcy, FDA approval for lead drug, delisting)
+- 0.0-0.2: Minor/routine (officer change with no strategic implications, bylaw amendment, warrant extension)
+- 0.2-0.5: Moderate (earnings roughly in-line, small acquisition, new credit facility, drill permit received)
+- 0.5-0.8: Significant (earnings beat/miss, major contract win/loss, material impairment, high-grade drill results, resource estimate upgrade)
+- 0.8-1.0: Transformative (change of control, bankruptcy, FDA approval for lead drug, delisting, discovery hole)
 
 Respond with valid JSON matching the requested schema. Be concise but specific."""
 
@@ -61,7 +61,12 @@ def build_messages(extracted: ExtractedFiling, financial_snapshot: FinancialSnap
 
     company = extracted.ticker or ticker
     accession = extracted.accession_number
-    user_parts.append(f"## 8-K Filing: {company} ({accession})\n")
+    is_press_release = extracted.form_type == "PRESS_RELEASE"
+
+    if is_press_release:
+        user_parts.append(f"## Press Release: {company} ({accession})\n")
+    else:
+        user_parts.append(f"## 8-K Filing: {company} ({accession})\n")
 
     if extracted.items:
         item_text = ""
@@ -74,6 +79,9 @@ def build_messages(extracted: ExtractedFiling, financial_snapshot: FinancialSnap
         for ex in extracted.exhibits:
             exhibit_text += f"### Exhibit: {ex.filename} (type: {ex.type})\n{ex.text}\n\n"
         user_parts.append(_truncate(exhibit_text.strip(), MAX_EXHIBIT_CHARS, f"exhibits for {accession}"))
+
+    if not extracted.items and not extracted.exhibits and extracted.text:
+        user_parts.append(_truncate(extracted.text, MAX_ITEM_CHARS, f"text for {accession}"))
 
     user_parts.append("## Financial Snapshot")
     if financial_snapshot.market_cap is not None:


### PR DESCRIPTION
## Summary
- `build_messages()` in `prompt.py` only sent 8-K `items` and `exhibits` to Sonnet — the `text` field (where press release content lives) was never included
- Every PR that passed Haiku prescreen was analyzed against an **empty prompt**, so Sonnet classified everything as NEUTRAL with magnitude 0.0 regardless of content
- Added fallback to include `extracted.text` when `items` and `exhibits` are empty
- Updated system prompt to reference press releases (not just 8-K filings) and added mining-relevant examples (drill results, resource estimates, permitting milestones) to classification/magnitude guidelines

**Impact:** Over the past 2 days, 75 press releases made it to Sonnet analysis but none received actual content. 0 alerts were sent. Several Canadian mining PRs with exploration results, drill permits, and geochem data were all classified NEUTRAL due to this bug.

## Test plan
- [ ] Deploy and verify that new press releases get non-empty `new_information`/`explanation` fields in `analysis.json`
- [ ] Confirm token usage increases (was ~700 tokens, should be proportional to PR text length)
- [ ] Verify 8-K filing analysis is unaffected (items/exhibits path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)