### PR TITLE
Add quant signal exploration workspace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "yfinance>=0.2",
     "pyyaml>=6.0",
     "click>=8.1",
+    "numpy>=1.24",
     "python-dotenv>=1.0",
     "mcp>=1.0",
     "websocket-client>=1.8",

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -27,6 +27,7 @@ from cli.macro import (
 )
 from cli.models import TickerRegistry, TickerRegistryEntry, UniverseConfig
 from cli.monitors import monitor
+from cli.quant import quant
 from cli.pipeline_interactive import interactive_pipeline_day_view, trace_payload
 from cli.pipeline_status import (
     build_pipeline_trace,
@@ -58,6 +59,7 @@ cli.add_command(monitor)
 cli.add_command(market)
 cli.add_command(watch)
 cli.add_command(alert)
+cli.add_command(quant)
 
 
 def _extract_tickers_from_monitor(monitor_data: dict) -> set[str]:

--- a/src/cli/quant.py
+++ b/src/cli/quant.py
@@ -1,0 +1,283 @@
+"""CLI commands for the quant signal workspace."""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import click
+import yaml
+
+from cli.config_utils import find_repo_root, get_config_dir, save_yaml
+from cli.quant_backtest import format_report, load_signal, run_backtest
+from cli.quant_data import fetch_ohlcv
+from cli.quant_prompt import generate_quant_prompt
+from cli.s3 import BUCKET, get_s3_client, list_prefix, upload_directory, download_file
+
+
+def _get_backtest_source() -> str:
+    """Read the backtest module source for copying into workspace."""
+    return (Path(__file__).parent / "quant_backtest.py").read_text()
+
+
+@click.group()
+def quant():
+    """Quant signal exploration workspace."""
+    pass
+
+
+@quant.command("init")
+@click.argument("tickers", nargs=-1, required=True)
+def quant_init(tickers: tuple[str, ...]):
+    """Initialize quant workspace for TICKER(s).
+
+    Fetches OHLCV data (daily + intraday), sets up backtest harness, and
+    generates a CLAUDE.md prompt for signal exploration.
+    """
+    repo_root = find_repo_root()
+
+    for raw_ticker in tickers:
+        ticker = raw_ticker.strip().upper()
+        click.echo(f"\n{'='*50}")
+        click.echo(f"Initializing quant workspace for {ticker}")
+        click.echo(f"{'='*50}")
+
+        workspace = repo_root / "workspace" / f"quant-{ticker}"
+        data_dir = workspace / "data"
+        lib_dir = workspace / "lib"
+        signals_dir = workspace / "signals"
+        results_dir = workspace / "results"
+
+        for d in [data_dir, lib_dir, signals_dir, results_dir]:
+            d.mkdir(parents=True, exist_ok=True)
+
+        # Fetch data for ticker + SPY benchmark
+        all_data_summary: dict[str, int] = {}
+
+        click.echo(f"\n  Fetching {ticker} data...")
+        ticker_summary = fetch_ohlcv(ticker, data_dir)
+        all_data_summary.update(ticker_summary)
+
+        click.echo(f"  Fetching SPY benchmark data...")
+        spy_summary = fetch_ohlcv("SPY", data_dir)
+        all_data_summary.update(spy_summary)
+
+        # Copy backtest harness
+        backtest_src = _get_backtest_source()
+        (lib_dir / "backtest.py").write_text(backtest_src)
+        # Also write __init__.py so lib is importable
+        (lib_dir / "__init__.py").write_text("")
+        click.echo(f"  Copied backtest harness to lib/backtest.py")
+
+        # Generate CLAUDE.md
+        prompt = generate_quant_prompt(ticker, all_data_summary)
+        (workspace / "CLAUDE.md").write_text(prompt)
+        click.echo(f"  Generated CLAUDE.md")
+
+        # Summary
+        click.echo(f"\n  Data summary:")
+        for fname, rows in sorted(all_data_summary.items()):
+            click.echo(f"    {fname}: {rows:,} rows")
+
+        click.echo(f"\n  Workspace ready: {workspace}")
+        click.echo(f"  cd {workspace} && claude")
+
+
+@quant.command("sync")
+@click.argument("tickers", nargs=-1)
+def quant_sync(tickers: tuple[str, ...]):
+    """Sync signals/ and results/ to S3, then clean up workspace.
+
+    If no tickers given, auto-discovers all workspace/quant-* dirs.
+    """
+    repo_root = find_repo_root()
+    workspace_root = repo_root / "workspace"
+
+    # Discover workspaces
+    if tickers:
+        dirs = [workspace_root / f"quant-{t.strip().upper()}" for t in tickers]
+    else:
+        dirs = sorted(workspace_root.glob("quant-*")) if workspace_root.exists() else []
+
+    if not dirs:
+        click.echo("No quant workspaces found.")
+        return
+
+    s3 = get_s3_client()
+
+    for ws_dir in dirs:
+        if not ws_dir.exists():
+            click.echo(f"  Workspace not found: {ws_dir}")
+            continue
+
+        ticker = ws_dir.name.replace("quant-", "")
+        click.echo(f"\nSyncing {ticker}...")
+
+        uploaded = 0
+        for subdir in ["signals", "results"]:
+            local = ws_dir / subdir
+            if local.exists() and any(local.iterdir()):
+                s3_prefix = f"data/quant/{ticker}/{subdir}"
+                keys = upload_directory(s3, local, s3_prefix)
+                uploaded += len(keys)
+                click.echo(f"  {subdir}/: {len(keys)} file(s) uploaded")
+
+        if uploaded > 0:
+            click.echo(f"  Cleaning up workspace...")
+            shutil.rmtree(ws_dir)
+            click.echo(f"  Done. {uploaded} file(s) synced to s3://{BUCKET}/data/quant/{ticker}/")
+        else:
+            click.echo(f"  No signals or results to sync.")
+
+
+@quant.command("promote")
+@click.argument("signal_id")
+@click.option("--ticker", "-t", help="Ticker (auto-detected from config if omitted)")
+def quant_promote(signal_id: str, ticker: str | None):
+    """Promote a validated signal to a live scraper monitor.
+
+    Finds the signal .py + .yaml in local workspace or S3, generates a
+    monitor config and self-contained scraper script.
+    """
+    repo_root = find_repo_root()
+    config_dir = get_config_dir()
+
+    # Find signal source: local workspace first, then S3
+    signal_py = None
+    signal_yaml = None
+
+    # Search local workspaces
+    for ws_dir in sorted((repo_root / "workspace").glob("quant-*")) if (repo_root / "workspace").exists() else []:
+        signals_dir = ws_dir / "signals"
+        if (signals_dir / f"{signal_id}.py").exists():
+            signal_py = (signals_dir / f"{signal_id}.py").read_text()
+            if (signals_dir / f"{signal_id}.yaml").exists():
+                signal_yaml = yaml.safe_load((signals_dir / f"{signal_id}.yaml").read_text())
+            if not ticker:
+                ticker = ws_dir.name.replace("quant-", "")
+            break
+
+    # Fallback to S3
+    if signal_py is None:
+        s3 = get_s3_client()
+        # Search all quant directories
+        quant_keys = list_prefix(s3, "data/quant/")
+        for key in quant_keys:
+            if key.endswith(f"signals/{signal_id}.py"):
+                signal_py = download_file(s3, key).decode()
+                yaml_key = key.replace(".py", ".yaml")
+                try:
+                    signal_yaml = yaml.safe_load(download_file(s3, yaml_key).decode())
+                except Exception:
+                    pass
+                if not ticker:
+                    # Extract ticker from key: data/quant/{TICKER}/signals/...
+                    parts = key.split("/")
+                    ticker = parts[2] if len(parts) > 2 else None
+                break
+
+    if signal_py is None:
+        raise click.ClickException(f"Signal '{signal_id}' not found in local workspaces or S3.")
+    if not ticker:
+        raise click.ClickException("Could not determine ticker. Use --ticker flag.")
+
+    config_yaml = signal_yaml or {}
+    description = config_yaml.get("description", f"Quant signal: {signal_id}")
+
+    # Generate monitor config
+    monitor_id = f"quant-{signal_id}"
+    monitor_config = {
+        "id": monitor_id,
+        "type": "scraper",
+        "tickers": [ticker],
+        "description": description,
+        "scraper_script": f"quant-{signal_id}",
+        "threshold": "Alert on signal state change (fires / stops firing)",
+    }
+
+    monitors_dir = config_dir / "monitors"
+    monitors_dir.mkdir(parents=True, exist_ok=True)
+    monitor_path = monitors_dir / f"{monitor_id}.yaml"
+    save_yaml(monitor_path, monitor_config)
+    click.echo(f"  Monitor config: {monitor_path}")
+
+    # Generate self-contained scraper script
+    scraper_script = _generate_scraper_script(signal_id, signal_py, ticker, config_yaml)
+    scrapers_dir = config_dir / "scrapers"
+    scrapers_dir.mkdir(parents=True, exist_ok=True)
+    scraper_path = scrapers_dir / f"quant-{signal_id}.py"
+    scraper_path.write_text(scraper_script)
+    click.echo(f"  Scraper script: {scraper_path}")
+
+    click.echo(f"\n  Signal '{signal_id}' promoted to live monitor.")
+    click.echo(f"  Run `praxis config sync` to deploy.")
+
+
+def _generate_scraper_script(
+    signal_id: str,
+    signal_source: str,
+    ticker: str,
+    config: dict,
+) -> str:
+    """Generate a self-contained scraper script that embeds the signal function."""
+    bar_size = config.get("bar_size", "1d")
+    lookback = config.get("lookback", 50)
+    # yfinance period mapping
+    period = "1y" if bar_size == "1d" else "7d"
+    interval = "1d" if bar_size == "1d" else "1m"
+
+    return f'''"""Auto-generated quant scraper for signal: {signal_id}
+
+Ticker: {ticker} | Bar size: {bar_size}
+Self-contained: fetches latest bars via yfinance, runs signal, returns result.
+"""
+import pandas as pd
+import numpy as np
+import yfinance as yf
+from datetime import datetime
+
+
+# === Embedded signal function ===
+{signal_source}
+# === End signal function ===
+
+
+def scrape():
+    """Run the signal and return result string.
+
+    Returns:
+        SIGNAL_FIRED|{{TICKER}}|{{date}}|{{price}}|{{volume}}
+        or NO_SIGNAL|{{TICKER}}|{{date}}
+    """
+    ticker = "{ticker}"
+    try:
+        t = yf.Ticker(ticker)
+        df = t.history(period="{period}", interval="{interval}")
+        if df.empty:
+            return f"ERROR|{{ticker}}|no data"
+
+        df = df.rename(columns={{
+            "Open": "open", "High": "high", "Low": "low",
+            "Close": "close", "Volume": "volume",
+        }})
+        df = df[["open", "high", "low", "close", "volume"]]
+
+        signals = signal(df)
+        if not isinstance(signals, pd.Series):
+            signals = pd.Series(signals, index=df.index)
+
+        latest_date = df.index[-1].strftime("%Y-%m-%d")
+        latest_price = df["close"].iloc[-1]
+        latest_volume = int(df["volume"].iloc[-1])
+
+        # Check if signal fires on the most recent bar
+        if signals.iloc[-1]:
+            return f"SIGNAL_FIRED|{{ticker}}|{{latest_date}}|{{latest_price:.2f}}|{{latest_volume}}"
+        else:
+            return f"NO_SIGNAL|{{ticker}}|{{latest_date}}"
+    except Exception as e:
+        return f"ERROR|{{ticker}}|{{e}}"
+
+
+if __name__ == "__main__":
+    print(scrape())
+'''

--- a/src/cli/quant_backtest.py
+++ b/src/cli/quant_backtest.py
@@ -1,0 +1,295 @@
+"""Backtest harness for quant signals.
+
+Self-contained: only imports pandas + numpy.
+Copied into workspace as lib/backtest.py so Claude can import it directly.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+import pandas as pd
+import yaml
+
+
+@dataclass
+class SignalConfig:
+    """Signal configuration loaded from YAML."""
+    signal_id: str
+    bar_size: str = "1d"
+    lookback: int = 50
+    hold_periods: list[int] = field(default_factory=lambda: [1, 5, 10, 20])
+    ticker: str = ""
+    description: str = ""
+
+
+@dataclass
+class HoldPeriodResult:
+    """Results for a single hold period."""
+    hold_period: int
+    signal_count: int
+    hit_rate: float
+    mean_return: float
+    median_return: float
+    sharpe: float
+    max_drawdown: float
+    t_stat: float
+    # Out-of-sample
+    oos_hit_rate: float | None = None
+    oos_mean_return: float | None = None
+    oos_sharpe: float | None = None
+    oos_signal_count: int | None = None
+
+
+@dataclass
+class BacktestResult:
+    """Full backtest result."""
+    signal_id: str
+    ticker: str
+    bar_size: str
+    total_bars: int
+    signal_count: int
+    signal_rate: float
+    hold_period_results: list[HoldPeriodResult]
+    beta: float | None = None
+    alpha: float | None = None
+    warnings: list[str] = field(default_factory=list)
+
+
+def _annualization_factor(bar_size: str) -> float:
+    """Return sqrt(periods_per_year) for Sharpe annualization."""
+    factors = {
+        "1d": np.sqrt(252),
+        "5m": np.sqrt(252 * 78),
+        "1m": np.sqrt(252 * 390),
+    }
+    return factors.get(bar_size, np.sqrt(252))
+
+
+def load_signal(signal_dir: Path, signal_id: str) -> tuple[Callable, SignalConfig]:
+    """Load a signal function and its config from the signals/ directory."""
+    py_path = signal_dir / f"{signal_id}.py"
+    yaml_path = signal_dir / f"{signal_id}.yaml"
+
+    if not py_path.exists():
+        raise FileNotFoundError(f"Signal file not found: {py_path}")
+    if not yaml_path.exists():
+        raise FileNotFoundError(f"Signal config not found: {yaml_path}")
+
+    # Load config
+    with open(yaml_path) as f:
+        cfg_data = yaml.safe_load(f)
+    config = SignalConfig(signal_id=signal_id, **{k: v for k, v in cfg_data.items() if k != "signal_id"})
+
+    # Load signal function
+    spec = importlib.util.spec_from_file_location(f"signal_{signal_id}", py_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    if not hasattr(mod, "signal"):
+        raise AttributeError(f"Signal module {py_path} must define a 'signal(df)' function")
+
+    return mod.signal, config
+
+
+def _compute_forward_returns(df: pd.DataFrame, periods: int) -> pd.Series:
+    """Compute forward returns over N periods."""
+    return df["close"].pct_change(periods).shift(-periods)
+
+
+def _compute_max_drawdown(returns: pd.Series) -> float:
+    """Max drawdown of a return series (as a negative number)."""
+    if returns.empty:
+        return 0.0
+    cumulative = (1 + returns).cumprod()
+    peak = cumulative.expanding().max()
+    drawdown = (cumulative - peak) / peak
+    return float(drawdown.min())
+
+
+def _compute_beta_alpha(
+    signal_returns: pd.Series,
+    benchmark_returns: pd.Series,
+) -> tuple[float, float]:
+    """Regress signal returns against benchmark for beta and alpha."""
+    aligned = pd.DataFrame({"signal": signal_returns, "bench": benchmark_returns}).dropna()
+    if len(aligned) < 10:
+        return 0.0, 0.0
+    x = aligned["bench"].values
+    y = aligned["signal"].values
+    x_mean = x.mean()
+    y_mean = y.mean()
+    beta = np.sum((x - x_mean) * (y - y_mean)) / (np.sum((x - x_mean) ** 2) + 1e-10)
+    alpha = y_mean - beta * x_mean
+    return float(beta), float(alpha)
+
+
+def run_backtest(
+    signal_fn: Callable,
+    config: SignalConfig,
+    data_dir: Path,
+    ticker: str | None = None,
+) -> BacktestResult:
+    """Run backtest for a signal function against OHLCV data."""
+    ticker = ticker or config.ticker
+    if not ticker:
+        raise ValueError("Ticker must be specified in config or as argument")
+
+    bar_size = config.bar_size
+    ann_factor = _annualization_factor(bar_size)
+
+    # Load data
+    data_path = data_dir / f"{ticker}_{bar_size}.csv"
+    if not data_path.exists():
+        raise FileNotFoundError(f"Data file not found: {data_path}")
+    df = pd.read_csv(data_path, index_col=0, parse_dates=True)
+    total_bars = len(df)
+
+    # Load benchmark
+    spy_path = data_dir / f"SPY_{bar_size}.csv"
+    spy_df = None
+    if spy_path.exists():
+        spy_df = pd.read_csv(spy_path, index_col=0, parse_dates=True)
+
+    # Run signal
+    signals = signal_fn(df)
+    if not isinstance(signals, pd.Series):
+        signals = pd.Series(signals, index=df.index)
+    signals = signals.astype(bool)
+
+    # Trim lookback
+    signals.iloc[:config.lookback] = False
+
+    signal_count = int(signals.sum())
+    signal_rate = signal_count / max(total_bars - config.lookback, 1)
+
+    warnings: list[str] = []
+    if signal_count < 20:
+        warnings.append(f"Low signal count ({signal_count}). Results may be unreliable.")
+
+    # Compute results for each hold period
+    hold_results: list[HoldPeriodResult] = []
+    for hp in config.hold_periods:
+        fwd_returns = _compute_forward_returns(df, hp)
+        # Mask: valid signals with valid forward returns
+        valid_mask = signals & fwd_returns.notna()
+        signal_rets = fwd_returns[valid_mask]
+        n = len(signal_rets)
+
+        if n == 0:
+            hold_results.append(HoldPeriodResult(
+                hold_period=hp, signal_count=0, hit_rate=0.0,
+                mean_return=0.0, median_return=0.0, sharpe=0.0,
+                max_drawdown=0.0, t_stat=0.0,
+            ))
+            continue
+
+        mean_ret = float(signal_rets.mean())
+        std_ret = float(signal_rets.std()) if n > 1 else 1.0
+        hit_rate = float((signal_rets > 0).mean())
+        sharpe = (mean_ret / (std_ret + 1e-10)) * ann_factor / np.sqrt(hp) if std_ret > 0 else 0.0
+        max_dd = _compute_max_drawdown(signal_rets)
+        t_stat = mean_ret / (std_ret / np.sqrt(n) + 1e-10) if n > 1 else 0.0
+
+        # OOS split if enough signals
+        oos_hit = oos_mean = oos_sharpe = None
+        oos_n = None
+        if n >= 30:
+            split = int(n * 0.7)
+            oos_rets = signal_rets.iloc[split:]
+            oos_n = len(oos_rets)
+            if oos_n > 0:
+                oos_hit = float((oos_rets > 0).mean())
+                oos_mean = float(oos_rets.mean())
+                oos_std = float(oos_rets.std()) if oos_n > 1 else 1.0
+                oos_sharpe = (oos_mean / (oos_std + 1e-10)) * ann_factor / np.sqrt(hp)
+
+        hold_results.append(HoldPeriodResult(
+            hold_period=hp, signal_count=n, hit_rate=hit_rate,
+            mean_return=mean_ret, median_return=float(signal_rets.median()),
+            sharpe=float(sharpe), max_drawdown=float(max_dd), t_stat=float(t_stat),
+            oos_hit_rate=oos_hit, oos_mean_return=oos_mean,
+            oos_sharpe=float(oos_sharpe) if oos_sharpe is not None else None,
+            oos_signal_count=oos_n,
+        ))
+
+    # Beta/alpha against SPY
+    beta = alpha = None
+    if spy_df is not None and signal_count > 0:
+        # Use 1-period forward returns for beta calc
+        fwd_1 = _compute_forward_returns(df, 1)
+        spy_fwd_1 = _compute_forward_returns(spy_df, 1)
+        valid = signals & fwd_1.notna()
+        sig_rets_1 = fwd_1[valid]
+        # Align by index
+        common_idx = sig_rets_1.index.intersection(spy_fwd_1.index)
+        if len(common_idx) >= 10:
+            beta, alpha = _compute_beta_alpha(
+                sig_rets_1.loc[common_idx],
+                spy_fwd_1.loc[common_idx],
+            )
+
+    return BacktestResult(
+        signal_id=config.signal_id,
+        ticker=ticker,
+        bar_size=bar_size,
+        total_bars=total_bars,
+        signal_count=signal_count,
+        signal_rate=signal_rate,
+        hold_period_results=hold_results,
+        beta=beta,
+        alpha=alpha,
+        warnings=warnings,
+    )
+
+
+def format_report(result: BacktestResult) -> str:
+    """Format backtest result as markdown."""
+    lines = [
+        f"# Backtest Report: {result.signal_id}",
+        f"",
+        f"**Ticker:** {result.ticker} | **Bar size:** {result.bar_size}",
+        f"**Total bars:** {result.total_bars:,} | **Signal fires:** {result.signal_count} ({result.signal_rate:.1%})",
+    ]
+
+    if result.beta is not None:
+        lines.append(f"**Beta:** {result.beta:.3f} | **Alpha (per bar):** {result.alpha:.5f}")
+
+    if result.warnings:
+        lines.append("")
+        for w in result.warnings:
+            lines.append(f"> WARNING: {w}")
+
+    lines.append("")
+    lines.append("## Results by Hold Period")
+    lines.append("")
+    lines.append("| Hold | N | Hit Rate | Mean Ret | Median Ret | Sharpe | MaxDD | t-stat |")
+    lines.append("|------|---|----------|----------|------------|--------|-------|--------|")
+    for hr in result.hold_period_results:
+        lines.append(
+            f"| {hr.hold_period}d | {hr.signal_count} | {hr.hit_rate:.1%} | "
+            f"{hr.mean_return:.3%} | {hr.median_return:.3%} | {hr.sharpe:.2f} | "
+            f"{hr.max_drawdown:.1%} | {hr.t_stat:.2f} |"
+        )
+
+    # OOS section
+    has_oos = any(hr.oos_hit_rate is not None for hr in result.hold_period_results)
+    if has_oos:
+        lines.append("")
+        lines.append("## Out-of-Sample Validation (30% holdout)")
+        lines.append("")
+        lines.append("| Hold | N | Hit Rate | Mean Ret | Sharpe |")
+        lines.append("|------|---|----------|----------|--------|")
+        for hr in result.hold_period_results:
+            if hr.oos_hit_rate is not None:
+                lines.append(
+                    f"| {hr.hold_period}d | {hr.oos_signal_count} | {hr.oos_hit_rate:.1%} | "
+                    f"{hr.oos_mean_return:.3%} | {hr.oos_sharpe:.2f} |"
+                )
+
+    lines.append("")
+    return "\n".join(lines)

--- a/src/cli/quant_data.py
+++ b/src/cli/quant_data.py
@@ -1,0 +1,166 @@
+"""OHLCV data fetching for quant workspaces."""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import click
+import pandas as pd
+import requests
+import yfinance as yf
+
+from cli.market_data import EODHD_BASE, get_eodhd_api_key, to_eodhd_symbol
+
+
+def _fetch_eodhd_daily(ticker: str, api_key: str, days: int = 365) -> pd.DataFrame | None:
+    """Fetch daily OHLCV from EODHD. Returns None on failure."""
+    sym = to_eodhd_symbol(ticker)
+    end = datetime.now()
+    start = end - timedelta(days=days)
+    try:
+        resp = requests.get(
+            f"{EODHD_BASE}/eod/{sym}",
+            params={
+                "period": "d",
+                "from": start.strftime("%Y-%m-%d"),
+                "to": end.strftime("%Y-%m-%d"),
+                "fmt": "json",
+                "api_token": api_key,
+            },
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if not data:
+            return None
+        df = pd.DataFrame(data)
+        df = df.rename(columns={
+            "date": "date",
+            "open": "open",
+            "high": "high",
+            "low": "low",
+            "close": "close",
+            "adjusted_close": "adjusted_close",
+            "volume": "volume",
+        })
+        df["date"] = pd.to_datetime(df["date"])
+        df = df.set_index("date")
+        df = df[["open", "high", "low", "close", "volume"]]
+        return df
+    except Exception as e:
+        click.echo(f"    EODHD daily failed for {ticker}: {e}")
+        return None
+
+
+def _fetch_eodhd_intraday(ticker: str, api_key: str, days: int = 120) -> pd.DataFrame | None:
+    """Fetch 1min intraday from EODHD. Returns None on failure."""
+    sym = to_eodhd_symbol(ticker)
+    end = int(datetime.now().timestamp())
+    start = int((datetime.now() - timedelta(days=days)).timestamp())
+    try:
+        resp = requests.get(
+            f"{EODHD_BASE}/intraday/{sym}",
+            params={
+                "interval": "1m",
+                "from": start,
+                "to": end,
+                "fmt": "json",
+                "api_token": api_key,
+            },
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if not data:
+            return None
+        df = pd.DataFrame(data)
+        df["date"] = pd.to_datetime(df["datetime"] if "datetime" in df.columns else df["timestamp"], utc=True)
+        df = df.set_index("date")
+        cols = [c for c in ["open", "high", "low", "close", "volume"] if c in df.columns]
+        df = df[cols]
+        if len(df) < 100:
+            return None
+        return df
+    except Exception as e:
+        click.echo(f"    EODHD intraday failed for {ticker}: {e}")
+        return None
+
+
+def _fetch_yfinance_daily(ticker: str, period: str = "1y") -> pd.DataFrame | None:
+    """Fetch daily OHLCV from yfinance."""
+    try:
+        t = yf.Ticker(ticker)
+        df = t.history(period=period, interval="1d")
+        if df.empty:
+            return None
+        df.index.name = "date"
+        df = df.rename(columns={"Open": "open", "High": "high", "Low": "low", "Close": "close", "Volume": "volume"})
+        df = df[["open", "high", "low", "close", "volume"]]
+        return df
+    except Exception as e:
+        click.echo(f"    yfinance daily failed for {ticker}: {e}")
+        return None
+
+
+def _fetch_yfinance_intraday(ticker: str) -> pd.DataFrame | None:
+    """Fetch 1min intraday from yfinance (max 7 days)."""
+    try:
+        t = yf.Ticker(ticker)
+        df = t.history(period="7d", interval="1m")
+        if df.empty or len(df) < 100:
+            return None
+        df.index.name = "date"
+        df = df.rename(columns={"Open": "open", "High": "high", "Low": "low", "Close": "close", "Volume": "volume"})
+        df = df[["open", "high", "low", "close", "volume"]]
+        return df
+    except Exception as e:
+        click.echo(f"    yfinance intraday failed for {ticker}: {e}")
+        return None
+
+
+def fetch_ohlcv(ticker: str, data_dir: Path) -> dict[str, int]:
+    """Fetch daily + intraday OHLCV for a ticker, save to data_dir.
+
+    Returns dict of filename -> row count for summary.
+    """
+    data_dir.mkdir(parents=True, exist_ok=True)
+    results: dict[str, int] = {}
+
+    # Try EODHD first, fallback to yfinance
+    api_key = None
+    try:
+        api_key = get_eodhd_api_key()
+    except click.ClickException:
+        pass
+
+    # Daily
+    df_daily = None
+    if api_key:
+        df_daily = _fetch_eodhd_daily(ticker, api_key)
+    if df_daily is None:
+        click.echo(f"    Falling back to yfinance for {ticker} daily...")
+        df_daily = _fetch_yfinance_daily(ticker)
+
+    if df_daily is not None and not df_daily.empty:
+        fname = f"{ticker}_1d.csv"
+        df_daily.to_csv(data_dir / fname)
+        results[fname] = len(df_daily)
+    else:
+        click.echo(f"    WARNING: No daily data for {ticker}")
+
+    # Intraday
+    df_intra = None
+    if api_key:
+        df_intra = _fetch_eodhd_intraday(ticker, api_key)
+    if df_intra is None:
+        df_intra = _fetch_yfinance_intraday(ticker)
+
+    if df_intra is not None and not df_intra.empty:
+        fname = f"{ticker}_1m.csv"
+        df_intra.to_csv(data_dir / fname)
+        results[fname] = len(df_intra)
+    else:
+        click.echo(f"    (no intraday data for {ticker} — not critical)")
+
+    return results

--- a/src/cli/quant_prompt.py
+++ b/src/cli/quant_prompt.py
@@ -1,0 +1,216 @@
+"""Generate CLAUDE.md prompt for quant signal workspaces."""
+from __future__ import annotations
+
+from datetime import date
+
+
+def generate_quant_prompt(
+    ticker: str,
+    data_summary: dict[str, int],
+) -> str:
+    """Generate CLAUDE.md for a quant workspace."""
+    today = date.today().isoformat()
+
+    # Build data manifest
+    manifest_lines = []
+    for fname, rows in sorted(data_summary.items()):
+        manifest_lines.append(f"- `data/{fname}` — {rows:,} rows")
+    data_manifest = "\n".join(manifest_lines) if manifest_lines else "- (no data files)"
+
+    return f"""# Quant Signal Workspace — {ticker}
+
+Generated: {today}
+
+---
+
+## Your Role
+
+You are a quantitative analyst exploring trading signals for **{ticker}**, a small/micro-cap
+stock where technical patterns are more likely to persist due to lower algorithmic coverage.
+
+Your job: discover, backtest, and validate signals that identify high-probability entry points.
+
+---
+
+## Available Data
+
+{data_manifest}
+
+**CSV schema:** `date,open,high,low,close,volume` (date is the index column)
+
+All prices are adjusted. Volume is share count.
+
+---
+
+## Signal Interface Contract
+
+Every signal MUST follow this exact interface:
+
+```python
+import pandas as pd
+import numpy as np
+
+def signal(df: pd.DataFrame) -> pd.Series:
+    \"\"\"
+    Args:
+        df: OHLCV DataFrame with columns [open, high, low, close, volume]
+            and a DatetimeIndex.
+    Returns:
+        Boolean Series (same index as df). True = signal fires on that bar.
+    \"\"\"
+    # Compute indicators from raw OHLCV — no pre-computed features
+    # Return boolean Series
+```
+
+**Rules:**
+- Input is raw OHLCV. Compute everything internally (moving averages, ratios, etc.)
+- Only import pandas and numpy — nothing else
+- Return a boolean Series with the same index as the input
+- The function must be identical in backtest and live execution
+- No lookahead bias — only use data available at or before each bar
+
+---
+
+## Signal Config (YAML)
+
+Each signal `.py` file has a matching `.yaml`:
+
+```yaml
+bar_size: "1d"          # Which data file to use: 1d or 1m
+lookback: 50            # Bars to skip at start (for indicator warmup)
+hold_periods: [1, 5, 10, 20]  # Forward return windows to test
+ticker: "{ticker}"
+description: "Brief description of what this signal detects"
+```
+
+---
+
+## Backtest Harness
+
+Use the provided harness:
+
+```python
+import sys
+sys.path.insert(0, ".")
+from lib.backtest import load_signal, run_backtest, format_report
+from pathlib import Path
+
+# Option 1: Load from signals/ directory
+signal_fn, config = load_signal(Path("signals"), "my_signal_id")
+result = run_backtest(signal_fn, config, Path("data"), ticker="{ticker}")
+print(format_report(result))
+
+# Option 2: Test inline signal
+from lib.backtest import SignalConfig
+def my_signal(df):
+    vol_ma = df["volume"].rolling(20).mean()
+    return df["volume"] > vol_ma * 3
+
+config = SignalConfig(signal_id="test", bar_size="1d", lookback=20, ticker="{ticker}")
+result = run_backtest(my_signal, config, Path("data"), ticker="{ticker}")
+print(format_report(result))
+```
+
+---
+
+## Strategy Philosophy
+
+**What works in small/micro-caps:**
+- **Volume anomalies** — Unusual volume often precedes price moves. Institutional accumulation
+  shows up as sustained above-average volume without proportional price movement.
+- **Accumulation/distribution** — Money flow analysis. Are large players building positions?
+- **Liquidity events** — Volume dry-ups followed by expansion. Breakouts from consolidation.
+- **Relative volume** — Volume relative to recent history matters more than absolute levels.
+- **Price-volume divergence** — Price making new lows on declining volume (selling exhaustion).
+
+**What to be skeptical of:**
+- Classical chart patterns (head & shoulders, cup & handle) — too subjective, low reproducibility
+- Single-indicator signals (RSI oversold alone) — too simple, heavily arbitraged
+- Mean reversion on small caps — these stocks trend; mean reversion works better on large caps
+
+---
+
+## Workflow
+
+1. **Explore the data** — Load CSVs, compute basic stats. Key questions:
+   - What's the overall trend? (trending stocks make any long-biased signal look good)
+   - What's the volume distribution? (median vs mean volume, spike frequency)
+   - Any regime changes? (different behavior in different periods)
+
+2. **Establish a baseline** — Before ANY signal, compute a naive baseline:
+   ```python
+   # "Buy random day" baseline: what are unconditional forward returns?
+   fwd_1 = df['close'].pct_change(1).shift(-1).dropna()
+   fwd_5 = df['close'].pct_change(5).shift(-5).dropna()
+   fwd_10 = df['close'].pct_change(10).shift(-10).dropna()
+   fwd_20 = df['close'].pct_change(20).shift(-20).dropna()
+   print(f"Baseline 1d: {{fwd_1.mean():.3%}} | 5d: {{fwd_5.mean():.3%}} | "
+         f"10d: {{fwd_10.mean():.3%}} | 20d: {{fwd_20.mean():.3%}}")
+   ```
+   **A signal must beat this baseline to have value.** If the stock is up 100% in the sample,
+   random entries average ~0.4%/day. Your signal needs to beat that, not just beat zero.
+
+3. **Hypothesize** — Form a specific, falsifiable hypothesis BEFORE looking at results.
+
+4. **Write signal** — Create `signals/{{id}}.py` and `signals/{{id}}.yaml`
+
+5. **Backtest** — Run the backtest harness. Compare to baseline. Check beta/alpha.
+   **Alpha matters more than raw returns** — if beta explains most of the return,
+   the signal is just "be long a trending stock."
+
+6. **Write report** — Save `results/{{id}}_report.md` with backtest output + your analysis.
+   Include the baseline comparison and beta-adjusted assessment.
+
+7. **Iterate** — Refine or try new hypotheses. Don't over-optimize a weak signal.
+
+---
+
+## Statistical Standards
+
+| Metric | Minimum for Promotion | Notes |
+|--------|----------------------|-------|
+| Signal fires | >= 20 (prefer 30+) | Fewer = unreliable statistics |
+| t-statistic | >= 2.0 | Below 2.0 is noise |
+| Hit rate | > 50% for long signals | Must beat random |
+| OOS validation | Required for promotion | 70/30 chronological split |
+| Sharpe ratio | > 0.5 annualized | Below is not worth trading |
+
+**Confidence interval on hit rate:** With N signals, 95% CI is approximately:
+`hit_rate +/- 1.96 * sqrt(hit_rate * (1 - hit_rate) / N)`
+
+If the lower bound of your CI includes 50%, your signal may not be real.
+
+---
+
+## Anti-Patterns (Avoid These)
+
+1. **Overfitting** — More than 3 tunable parameters on fewer than 50 signal fires is suspicious.
+   A good signal is simple and robust to parameter changes.
+
+2. **Data snooping** — Testing 20 signals and reporting the best one. Each signal should come
+   from a hypothesis, not from mining.
+
+3. **Ignoring transaction costs** — For intraday signals, assume 0.1% round-trip cost. For
+   daily, assume 0.2% round-trip (wider spreads on small caps).
+
+4. **Cherry-picking hold periods** — If a signal only works at exactly 7 days but not 5 or 10,
+   it's likely noise.
+
+5. **Lookahead bias** — Using future data in signal computation. The signal function only
+   receives data up to the current bar.
+
+6. **Trend confound** — In a strongly trending stock, ANY long-biased dip-buying signal looks
+   amazing. Always compare to the unconditional baseline. If your signal's mean return is only
+   marginally better than "buy random day," the signal isn't adding value — you're just long.
+
+7. **Survivorship bias** — Not relevant here (single-stock analysis), but be aware if comparing
+   across tickers.
+
+---
+
+## After Analysis
+
+When done exploring, the human will run:
+- `praxis quant sync {ticker}` to upload signals/ and results/ to S3
+- `praxis quant promote {{signal_id}}` to create a live monitor from a validated signal
+"""


### PR DESCRIPTION
## Summary
- New `praxis quant` CLI with `init`, `sync`, and `promote` commands
- Scaffolds workspace with OHLCV data (EODHD + yfinance fallback), backtest harness, and quant-focused CLAUDE.md
- Signal contract: `signal(df) -> pd.Series[bool]` — identical in backtest and live execution
- Promote command generates self-contained scraper scripts for live monitoring
- Tested on AGM and AAOI — CLAUDE.md prompt produces honest, skeptical analysis with baseline comparisons

## Test plan
- [x] `praxis quant init AGM` — creates workspace with daily + intraday data, CLAUDE.md, backtest harness
- [x] Backtest harness works with inline and file-based signals
- [x] Claude agent produces useful signal exploration with honest statistical assessment
- [x] Prompt correctly guides skepticism about trend-confounded results
- [ ] `praxis quant sync` — uploads to S3 (manual test)
- [ ] `praxis quant promote` — generates monitor config + scraper (manual test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)