### PR TITLE
Strip API keys from Claude CLI subprocesses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,5 +22,13 @@ The system runs an automated monitoring pipeline that may produce artifacts you 
 
 Monitor snapshots are stored in S3 under `data/monitors/{monitor_id}/latest.yaml`. Filing analyses under `data/raw/filings/`. When you see analysis artifacts from these systems (e.g. in `--tactical` context), they are machine-generated summaries — treat them as inputs to your own analysis, not conclusions.
 
+## Claude CLI subprocess safety — CRITICAL
+When spawning Claude CLI as a subprocess (e.g. `claude -p`), you **MUST** strip all API key environment variables (`ANTHROPIC_API_KEY`, `CLAUDE_API_KEY`) from the child process environment. This forces the CLI to use the Max subscription instead of API billing. Failure to do this has previously caused hundreds of dollars in unexpected API charges.
+
+- In Python: `env.pop("ANTHROPIC_API_KEY", None)` and `env.pop("CLAUDE_API_KEY", None)` before `subprocess.run(..., env=env)`.
+- In shell scripts: `unset ANTHROPIC_API_KEY CLAUDE_API_KEY` at the top of the script.
+- **Never** pass `ANTHROPIC_API_KEY` to a Claude CLI subprocess. If the CLI can't authenticate via Max, it should fail loudly — that's the correct behavior.
+- This does NOT apply to LiteLLM calls in the monitoring pipeline (`src/modules/common/llm.py`, filing analyzers), which intentionally use the API for Lambda-deployed workloads.
+
 ## Price data
 Use the `get_price(ticker)` MCP tool for current/delayed stock prices. Do NOT web search for prices.

--- a/scripts/batch_analyze.sh
+++ b/scripts/batch_analyze.sh
@@ -8,6 +8,13 @@
 
 set -euo pipefail
 
+# ---- SAFETY: prevent Claude CLI from using API billing ----
+# Strip any Anthropic API key so Claude CLI uses Max plan only.
+# If no Max subscription is active, the CLI will error out — which is
+# the correct behaviour (fail loudly instead of billing silently).
+unset ANTHROPIC_API_KEY 2>/dev/null || true
+unset CLAUDE_API_KEY 2>/dev/null || true
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PRAXIS="$REPO_ROOT/.venv/bin/praxis"
 UNIVERSE="$REPO_ROOT/config/universe.yaml"

--- a/src/cli/research_run.py
+++ b/src/cli/research_run.py
@@ -277,6 +277,10 @@ def _run_session(
     env = os.environ.copy()
     env.pop("CLAUDE_CODE_ENTRYPOINT", None)
     env.pop("CLAUDECODE", None)
+    # SAFETY: strip ALL API key env vars to prevent Claude CLI from using
+    # API billing. We want it to use the Max subscription only.
+    env.pop("ANTHROPIC_API_KEY", None)
+    env.pop("CLAUDE_API_KEY", None)
 
     try:
         result = subprocess.run(


### PR DESCRIPTION
## Summary
- Strip `ANTHROPIC_API_KEY` and `CLAUDE_API_KEY` from env in all Claude CLI subprocess calls to force Max subscription usage
- `batch_analyze.sh` had zero safeguards — now `unset`s keys at script top
- `research_run.py` already stripped `ANTHROPIC_API_KEY`, added `CLAUDE_API_KEY` too
- Documented the rule in CLAUDE.md (does not apply to Lambda LiteLLM calls which intentionally use the API)

## Test plan
- [ ] Run `praxis research run` and confirm it uses Max, not API billing
- [ ] Run `batch_analyze.sh` in dry-run mode and confirm keys are unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)