### PR TITLE
Fix filing pipeline reliability + observability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/com.praxis.analyst.plist
+++ b/com.praxis.analyst.plist
@@ -12,6 +12,10 @@
     </array>
     <key>KeepAlive</key>
     <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>ExitTimeOut</key>
+    <integer>60</integer>
     <key>WorkingDirectory</key>
     <string>/Users/avyukdixit/dev/praxis-copilot</string>
     <key>StandardOutPath</key>

--- a/com.praxis.filing-research.plist
+++ b/com.praxis.filing-research.plist
@@ -12,6 +12,10 @@
     </array>
     <key>KeepAlive</key>
     <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>ExitTimeOut</key>
+    <integer>60</integer>
     <key>WorkingDirectory</key>
     <string>/Users/avyukdixit/dev/praxis-copilot</string>
     <key>StandardOutPath</key>

--- a/com.praxis.manage.plist
+++ b/com.praxis.manage.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.praxis.manage</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/avyukdixit/dev/praxis-copilot/.venv/bin/praxis</string>
+        <string>manage</string>
+        <string>daemon</string>
+    </array>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>ExitTimeOut</key>
+    <integer>60</integer>
+    <key>WorkingDirectory</key>
+    <string>/Users/avyukdixit/dev/praxis-copilot</string>
+    <key>StandardOutPath</key>
+    <string>/Users/avyukdixit/dev/praxis-copilot/logs/manage.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/avyukdixit/dev/praxis-copilot/logs/manage.err</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/Users/avyukdixit/.local/bin</string>
+        <key>SNS_TOPIC_ARN</key>
+        <string>arn:aws:sns:us-east-1:703222328817:8k-scanner-alerts</string>
+        <key>AWS_DEFAULT_REGION</key>
+        <string>us-east-1</string>
+    </dict>
+</dict>
+</plist>

--- a/com.praxis.research-queue.plist
+++ b/com.praxis.research-queue.plist
@@ -12,6 +12,10 @@
     </array>
     <key>KeepAlive</key>
     <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>ExitTimeOut</key>
+    <integer>60</integer>
     <key>WorkingDirectory</key>
     <string>/Users/avyukdixit/dev/praxis-copilot</string>
     <key>StandardOutPath</key>

--- a/com.praxis.scanner.plist
+++ b/com.praxis.scanner.plist
@@ -16,6 +16,10 @@
     </array>
     <key>KeepAlive</key>
     <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>ExitTimeOut</key>
+    <integer>60</integer>
     <key>WorkingDirectory</key>
     <string>/Users/avyukdixit/dev/praxis-copilot</string>
     <key>StandardOutPath</key>

--- a/playground/todo-4-6.md
+++ b/playground/todo-4-6.md
@@ -1,0 +1,13 @@
+# TODO 2026-04-06
+
+- [x] Fix NEUTRAL alerts with mag >= 0.5 being emailed — scanner alert filter now skips SELL/HOLD/NEUTRAL
+- [x] Add `praxis scanner show <TICKER>` command — pulls and prints analysis.json from S3, shows prescreen info for NEGATIVE items
+- [x] BUG: scan_unanalyzed() (backfill path) now sends alerts matching run_full_pipeline behavior
+- [x] Add discovered_at timestamps to skipped filings section in HTML report
+- [x] Show source type in skipped filings section (Canadian PR, US PR, 8-K, etc.)
+- [x] Show prescreen NEGATIVE filings distinctly — _evaluate_filing now checks screening.json and sets SKIP_SCREENED with reason "prescreened NEGATIVE by Haiku". CSS highlights pending vs screened rows.
+- [x] Robust to computer restarts — added ThrottleInterval + ExitTimeOut to all 4 plists, created scripts/daemon-health.sh to re-enable disabled daemons
+- [x] Fix yfinance multi-level columns breaking price charts
+- [x] Fix yfinance thread-safety — serialized parallel downloads that returned corrupted data
+- [x] Daemon report regen now logs errors properly (logger.error + exc_info) and falls back to skip_charts=True if price fetch fails
+- [ ] INVESTIGATE: filing-research daemon sync_research() logged "Synced N file(s)" for last week's runs but artifacts weren't on S3. Today's ONMD synced fine via daemon. Monitor new completions.

--- a/scripts/daemon-health.sh
+++ b/scripts/daemon-health.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Health check script for praxis daemons.
+# Re-enables and bootstraps any daemons that launchd has disabled.
+# Run manually or via cron after reboot.
+
+set -euo pipefail
+
+GUI_DOMAIN="gui/$(id -u)"
+LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
+
+DAEMONS=(
+    "com.praxis.scanner"
+    "com.praxis.filing-research"
+    "com.praxis.analyst"
+    "com.praxis.research-queue"
+)
+
+for daemon in "${DAEMONS[@]}"; do
+    plist="$LAUNCH_AGENTS/$daemon.plist"
+
+    if [ ! -f "$plist" ]; then
+        echo "WARN: $daemon — plist not found at $plist"
+        continue
+    fi
+
+    # Check if disabled
+    disabled=$(launchctl print-disabled "$GUI_DOMAIN" 2>/dev/null | grep "\"$daemon\"" | grep -c "disabled" || true)
+    if [ "$disabled" -gt 0 ]; then
+        echo "FIXING: $daemon is disabled — re-enabling..."
+        launchctl enable "$GUI_DOMAIN/$daemon"
+    fi
+
+    # Check if loaded
+    loaded=$(launchctl list 2>/dev/null | grep -c "$daemon" || true)
+    if [ "$loaded" -eq 0 ]; then
+        echo "FIXING: $daemon not loaded — bootstrapping..."
+        launchctl bootstrap "$GUI_DOMAIN" "$plist" 2>/dev/null || true
+    fi
+
+    # Check status
+    info=$(launchctl list 2>/dev/null | grep "$daemon" || echo "NOT RUNNING")
+    pid=$(echo "$info" | awk '{print $1}')
+    exit_code=$(echo "$info" | awk '{print $2}')
+
+    if [ "$pid" = "-" ] || [ "$pid" = "NOT" ]; then
+        echo "DOWN: $daemon (exit=$exit_code)"
+    else
+        echo "  OK: $daemon (pid=$pid)"
+    fi
+done

--- a/scripts/daemon-health.sh
+++ b/scripts/daemon-health.sh
@@ -13,6 +13,7 @@ DAEMONS=(
     "com.praxis.filing-research"
     "com.praxis.analyst"
     "com.praxis.research-queue"
+    "com.praxis.manage"
 )
 
 for daemon in "${DAEMONS[@]}"; do

--- a/src/cli/filing_research.py
+++ b/src/cli/filing_research.py
@@ -490,6 +490,17 @@ def run_daemon(
     state = _load_state(run_date)
     state.started_at = state.started_at or now_et
     state.daemon_pid = os.getpid()
+
+    # Recover stuck research_running entries from previous daemon instance
+    stuck_count = 0
+    for filing in state.filings.values():
+        if filing.decision == FilingDecision.RESEARCH_RUNNING and filing.research_finished_at is None:
+            filing.decision = FilingDecision.RESEARCH_QUEUED
+            filing.research_started_at = None
+            stuck_count += 1
+    if stuck_count:
+        logger.info("Recovered %d stuck research_running entries from previous daemon", stuck_count)
+
     _save_state(state)
 
     # Load config

--- a/src/cli/filing_research.py
+++ b/src/cli/filing_research.py
@@ -194,6 +194,16 @@ def _evaluate_filing(
         analysis_raw = download_file(s3, f"{item.key_prefix}/analysis.json")
         analysis = json.loads(analysis_raw)
     except Exception:
+        # Check if prescreen rejected it (screening.json with NEGATIVE result)
+        try:
+            screening_raw = download_file(s3, f"{item.key_prefix}/screening.json")
+            screening = json.loads(screening_raw)
+            if screening.get("result") == "NEGATIVE":
+                tracked.decision = FilingDecision.SKIP_SCREENED
+                tracked.decision_reason = "prescreened NEGATIVE by Haiku"
+                return tracked
+        except Exception:
+            pass
         tracked.decision = FilingDecision.SKIP_NOT_ANALYZED
         tracked.decision_reason = "no analysis.json found"
         return tracked
@@ -613,7 +623,13 @@ def run_daemon(
                     from cli.filing_research_report import generate_and_write_report
                     generate_and_write_report(date_str=run_date, skip_charts=False, open_browser=False, quiet=True)
                 except Exception as e:
-                    logger.debug("Report regeneration failed: %s", e)
+                    logger.error("Report regeneration failed: %s", e, exc_info=True)
+                    # Retry without charts — price fetch is the most fragile part
+                    try:
+                        generate_and_write_report(date_str=run_date, skip_charts=True, open_browser=False, quiet=True)
+                        logger.info("Report regenerated without charts (fallback)")
+                    except Exception as e2:
+                        logger.error("Report regeneration fallback also failed: %s", e2)
 
             # Submit new research jobs (only up to max_parallel, respecting capacity)
             if executor and not past_window:

--- a/src/cli/filing_research.py
+++ b/src/cli/filing_research.py
@@ -645,14 +645,23 @@ def run_daemon(
             # Submit new research jobs (only up to max_parallel, respecting capacity)
             if executor and not past_window:
                 # Check capacity before submitting new work
-                # Capacity gate removed — 80% cap was never calibrated against
-                # real rate limits. Log usage for observability but don't block.
+                # Adaptive capacity gate: only throttle if we've actually hit a
+                # rate limit before (calibrated). Pre-calibration we run uncapped
+                # to discover the real limit, then respect 80% going forward.
                 try:
                     from cli.telemetry import get_capacity_estimate
                     cap = get_capacity_estimate()
                     pct = cap.get("estimated_pct", 0)
-                    if pct >= 80 and not pending_futures:
-                        click.echo(f"[{datetime.now(ET).strftime('%H:%M:%S')}] Capacity at {pct}% (not gating)")
+                    calibrated = cap.get("calibrated", False)
+                    if calibrated and cap.get("at_target", False):
+                        if not pending_futures:
+                            click.echo(f"[{datetime.now(ET).strftime('%H:%M:%S')}] At {pct}% capacity (calibrated), waiting...")
+                        _save_state(state)
+                        time.sleep(60)
+                        continue
+                    elif pct >= 80 and not pending_futures:
+                        label = "calibrated" if calibrated else "uncalibrated, not gating"
+                        click.echo(f"[{datetime.now(ET).strftime('%H:%M:%S')}] Capacity at {pct}% ({label})")
                 except Exception:
                     pass
 

--- a/src/cli/filing_research.py
+++ b/src/cli/filing_research.py
@@ -645,15 +645,14 @@ def run_daemon(
             # Submit new research jobs (only up to max_parallel, respecting capacity)
             if executor and not past_window:
                 # Check capacity before submitting new work
+                # Capacity gate removed — 80% cap was never calibrated against
+                # real rate limits. Log usage for observability but don't block.
                 try:
                     from cli.telemetry import get_capacity_estimate
                     cap = get_capacity_estimate()
-                    if cap.get("at_target", False):
-                        if not pending_futures:  # Only log if we'd otherwise be idle
-                            click.echo(f"[{datetime.now(ET).strftime('%H:%M:%S')}] At 80% capacity, waiting...")
-                        _save_state(state)
-                        time.sleep(60)
-                        continue
+                    pct = cap.get("estimated_pct", 0)
+                    if pct >= 80 and not pending_futures:
+                        click.echo(f"[{datetime.now(ET).strftime('%H:%M:%S')}] Capacity at {pct}% (not gating)")
                 except Exception:
                     pass
 

--- a/src/cli/filing_research_report.py
+++ b/src/cli/filing_research_report.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import click
+import pandas as pd
 import requests
 import yaml
 
@@ -84,6 +85,9 @@ def _fetch_ohlc_yfinance(ticker: str, days: int = 30) -> list[dict] | None:
         df = yf.download(ticker, start=start.isoformat(), end=end.isoformat(), progress=False)
         if df is None or df.empty:
             return None
+        # Flatten multi-level columns from newer yfinance versions
+        if isinstance(df.columns, pd.MultiIndex):
+            df.columns = df.columns.get_level_values(0)
         results = []
         for idx, row in df.iterrows():
             results.append(
@@ -137,16 +141,15 @@ def fetch_all_ohlc(tickers: list[str], days: int = 30) -> dict[str, list[dict]]:
             tickers_to_fetch.append(t)
 
     if tickers_to_fetch:
-        with ThreadPoolExecutor(max_workers=5) as pool:
-            futures = {pool.submit(fetch_ohlc, t, days): t for t in tickers_to_fetch}
-            for future in as_completed(futures):
-                ticker = futures[future]
-                try:
-                    data = future.result()
-                    results[ticker] = data
-                    cache[ticker] = {"date": today, "data": data}
-                except Exception:
-                    results[ticker] = []
+        # Serialize fetches — yfinance is not thread-safe and returns
+        # corrupted data when multiple downloads run in parallel.
+        for ticker in tickers_to_fetch:
+            try:
+                data = fetch_ohlc(ticker, days)
+                results[ticker] = data
+                cache[ticker] = {"date": today, "data": data}
+            except Exception:
+                results[ticker] = []
 
         # Save cache
         try:
@@ -515,22 +518,50 @@ def _render_filing_card(
 </div>"""
 
 
+def _source_label(filing: TrackedFiling) -> str:
+    """Human-readable source label from key_prefix and form_type."""
+    kp = filing.key_prefix or ""
+    if filing.form_type:
+        return filing.form_type
+    if "newsfile" in kp:
+        return "Canadian PR"
+    if "/gnw/" in kp:
+        return "US PR"
+    if "press_releases" in kp:
+        return "PR"
+    return "—"
+
+
 def _render_skipped_table(skipped: list[TrackedFiling]) -> str:
     if not skipped:
         return ""
     rows = []
-    for f in sorted(skipped, key=lambda x: x.discovered_at):
+    for f in sorted(skipped, key=lambda x: x.discovered_at, reverse=True):
         ticker = html.escape(f.ticker or "—")
-        form = html.escape(f.form_type or "—")
+        source = html.escape(_source_label(f))
         cls = html.escape(f.classification[:10] if f.classification else "—")
         mag = f"{f.magnitude:.2f}" if f.magnitude is not None else "—"
-        reason = html.escape(f.decision_reason)
-        rows.append(f"<tr><td>{ticker}</td><td>{form}</td><td>{cls}</td><td>{mag}</td><td>{reason}</td></tr>")
+        time_str = f.discovered_at.strftime("%H:%M") if f.discovered_at else "—"
+        reason = html.escape(f.decision_reason or "")
+
+        # Distinguish prescreen rejections
+        if f.decision == FilingDecision.SKIP_SCREENED:
+            reason_cls = "skip-screened"
+        elif f.decision == FilingDecision.SKIP_NOT_ANALYZED:
+            reason_cls = "skip-pending"
+        else:
+            reason_cls = ""
+
+        rows.append(
+            f'<tr class="{reason_cls}">'
+            f"<td>{time_str}</td><td>{ticker}</td><td>{source}</td>"
+            f"<td>{cls}</td><td>{mag}</td><td>{reason}</td></tr>"
+        )
     return f"""\
 <details class="skipped-section">
   <summary>Skipped Filings ({len(skipped)})</summary>
   <table class="skipped-table">
-    <thead><tr><th>Ticker</th><th>Form</th><th>Class</th><th>Mag</th><th>Reason</th></tr></thead>
+    <thead><tr><th>Time</th><th>Ticker</th><th>Source</th><th>Class</th><th>Mag</th><th>Reason</th></tr></thead>
     <tbody>{"".join(rows)}</tbody>
   </table>
 </details>"""
@@ -667,6 +698,8 @@ h1.title { font-size: 22px; margin-bottom: 4px; }
   border-bottom: 1px solid #334155;
 }
 .skipped-table td { padding: 4px 10px; color: #cbd5e1; border-bottom: 1px solid #1e293b; }
+.skip-screened td { color: #64748b; }
+.skip-pending td { color: #fbbf24; }
 .briefing {
   background: #172554; border: 1px solid #1e40af; border-radius: 10px;
   padding: 16px 20px; margin-bottom: 24px;

--- a/src/cli/local_scanner.py
+++ b/src/cli/local_scanner.py
@@ -348,7 +348,7 @@ def run_full_pipeline(
 
     for item, analysis in results:
         classification = (analysis.get("classification") or "").upper()
-        if classification in ("SELL", "HOLD"):
+        if classification in ("SELL", "HOLD", "NEUTRAL"):
             continue
         if analysis["magnitude"] >= alert_threshold:
             _send_alert(item, analysis)
@@ -691,6 +691,7 @@ def scan_unanalyzed(
     prescreen: bool = True,
     dry_run: bool = False,
     model: str = "sonnet",
+    alert_threshold: float = 0.5,
 ) -> dict:
     """Find items in S3 with extracted.json but no analysis.json and analyze them."""
     from cli.s3 import list_prefix_objects
@@ -763,6 +764,7 @@ def scan_unanalyzed(
             future = executor.submit(_analyze_pipeline_item, s3, item, prescreen, model)
             futures[future] = item
 
+        alert_results = []
         for future in as_completed(futures):
             item = futures[future]
             try:
@@ -773,11 +775,22 @@ def scan_unanalyzed(
                         f"  {result['classification']} (mag={result['magnitude']:.2f}): "
                         f"{item['ticker']}"
                     )
+                    alert_results.append((item, result))
             except Exception as e:
                 logger.error("Error: %s", e)
 
-    click.echo(f"\nDone: {analyzed} analyzed")
-    return {"found": len(items), "analyzed": analyzed}
+    # Send alerts for high-magnitude BUY items (matching run_full_pipeline behavior)
+    alerted = 0
+    for item, analysis in alert_results:
+        classification = (analysis.get("classification") or "").upper()
+        if classification in ("SELL", "HOLD", "NEUTRAL"):
+            continue
+        if analysis["magnitude"] >= alert_threshold:
+            _send_alert(item, analysis)
+            alerted += 1
+
+    click.echo(f"\nDone: {analyzed} analyzed, {alerted} alerted")
+    return {"found": len(items), "analyzed": analyzed, "alerted": alerted}
 
 
 # ---------------------------------------------------------------------------
@@ -881,6 +894,93 @@ def scanner_analyze(s3_path: str):
         click.echo(json.dumps(result, indent=2, default=str))
     else:
         click.echo("Analysis failed.")
+
+
+@scanner.command("show")
+@click.argument("ticker")
+def scanner_show(ticker: str):
+    """Show the latest scanner analysis for a ticker.
+
+    \b
+    Searches S3 for the most recent analysis.json for the given ticker
+    across both filings and press releases.
+
+    Examples:
+      praxis scanner show PFSA
+      praxis scanner show HASH.V
+    """
+    s3 = get_s3_client()
+    from cli.s3 import list_prefix_objects
+
+    ticker_upper = ticker.upper()
+    # Normalize: HASH.V -> search for HASH in press_releases, HASH.V in filings
+    ticker_bare = ticker_upper.split(".")[0] if "." in ticker_upper else ticker_upper
+
+    candidates = []
+
+    # Search press releases (stored without exchange suffix)
+    for source in ["gnw", "newsfile"]:
+        prefix = f"data/raw/press_releases/{source}/{ticker_bare}/"
+        objects = list_prefix_objects(s3, prefix)
+        dirs: dict[str, datetime | None] = {}
+        for obj in objects:
+            key = obj["Key"]
+            parts = key.rsplit("/", 1)
+            if len(parts) == 2 and parts[1] == "analysis.json":
+                dirs[parts[0]] = obj.get("LastModified")
+        for parent, ts in dirs.items():
+            candidates.append((parent, ts))
+
+    # Search filings by CIK if we can resolve it
+    try:
+        from cli.edgar import resolve_ticker
+        info = resolve_ticker(ticker_upper)
+        if info:
+            prefix = f"data/raw/filings/{info.cik}/"
+            objects = list_prefix_objects(s3, prefix)
+            for obj in objects:
+                key = obj["Key"]
+                parts = key.rsplit("/", 1)
+                if len(parts) == 2 and parts[1] == "analysis.json":
+                    candidates.append((parts[0], obj.get("LastModified")))
+    except Exception:
+        pass
+
+    if not candidates:
+        # Also check screening.json for prescreened items
+        screened = False
+        for source in ["gnw", "newsfile"]:
+            prefix = f"data/raw/press_releases/{source}/{ticker_bare}/"
+            objects = list_prefix_objects(s3, prefix)
+            for obj in objects:
+                if obj["Key"].endswith("screening.json"):
+                    raw = download_file(s3, obj["Key"])
+                    screening = json.loads(raw)
+                    click.echo(f"No analysis found for {ticker_upper}.")
+                    click.echo(f"Prescreen result: {screening.get('result', 'unknown')}")
+                    click.echo(f"Screened at: {screening.get('screened_at', 'unknown')}")
+                    screened = True
+                    break
+            if screened:
+                break
+        if not screened:
+            click.echo(f"No analysis or screening found for {ticker_upper} on S3.")
+        return
+
+    # Sort by timestamp, most recent first
+    candidates.sort(key=lambda x: x[1] or datetime.min.replace(tzinfo=ET), reverse=True)
+
+    for parent, ts in candidates:
+        try:
+            raw = download_file(s3, f"{parent}/analysis.json")
+            analysis = json.loads(raw)
+            ts_str = ts.strftime("%Y-%m-%d %H:%M ET") if ts else "unknown"
+            click.echo(f"=== {ticker_upper} — {parent} ===")
+            click.echo(f"Analyzed: {ts_str}")
+            click.echo(json.dumps(analysis, indent=2, default=str))
+            click.echo()
+        except Exception:
+            continue
 
 
 @scanner.command("daemon")
@@ -993,6 +1093,7 @@ def scanner_daemon(poll_interval: int, start_hour: int, end_hour: int, after_hou
                         max_parallel=max_parallel,
                         prescreen=True,
                         model=model,
+                        alert_threshold=alert_threshold,
                     )
                 except Exception as e:
                     logger.error("Post-throttle backfill failed: %s", e)
@@ -1026,6 +1127,7 @@ def scanner_daemon(poll_interval: int, start_hour: int, end_hour: int, after_hou
                         max_parallel=max_parallel,
                         prescreen=True,
                         model=model,
+                        alert_threshold=alert_threshold,
                     )
                 except Exception as e:
                     logger.error("After-hours sweep failed: %s", e)
@@ -1060,6 +1162,7 @@ def scanner_daemon(poll_interval: int, start_hour: int, end_hour: int, after_hou
                     max_parallel=max_parallel,
                     prescreen=True,
                     model=model,
+                    alert_threshold=alert_threshold,
                 )
             except Exception as e:
                 logger.error("Scan cycle failed: %s", e)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -59,6 +59,7 @@ from cli.research_queue import research_queue_cli
 from cli.thesis_monitors import watches_cli
 from cli.event_calendar import events_cli
 from cli.local_scanner import scanner
+from cli.manage_cli import manage
 from cli.queue_cli import queue
 from cli.watch import alert, market, watch
 
@@ -84,6 +85,7 @@ cli.add_command(watchdog)
 cli.add_command(portfolio_cli, "portfolio")
 cli.add_command(watches_cli, "watches")
 cli.add_command(research_queue_cli, "research-queue")
+cli.add_command(manage)
 
 
 @cli.group("desktop")

--- a/src/cli/manage_cli.py
+++ b/src/cli/manage_cli.py
@@ -1,0 +1,91 @@
+"""Local CLI for the manage (price alert) pipeline.
+
+Replaces the Lambda-based manage pipeline with a local daemon that uses
+yfinance as the price source. Generates the same alerts.yaml files in S3
+that the analyst daemon consumes.
+"""
+from __future__ import annotations
+
+import logging
+import time as _time
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import click
+
+logger = logging.getLogger(__name__)
+ET = ZoneInfo("America/New_York")
+
+
+@click.group("manage")
+def manage():
+    """Price alert pipeline — intraday threshold checks."""
+    pass
+
+
+@manage.command("run")
+def manage_run():
+    """Run a single intraday price check pass."""
+    from modules.manage.handler import _handle_intraday
+
+    result = _handle_intraday()
+    click.echo(f"Checked {result.get('tickers_checked', 0)} tickers, "
+               f"{result.get('alerts_generated', 0)} alerts generated")
+    if result.get("errors"):
+        for err in result["errors"]:
+            click.echo(f"  ERROR: {err}")
+
+
+@manage.command("daemon")
+@click.option("--poll-interval", type=int, default=900, show_default=True,
+              help="Seconds between checks (default 15 min)")
+@click.option("--start-hour", type=int, default=9, show_default=True,
+              help="Start hour ET")
+@click.option("--end-hour", type=int, default=16, show_default=True,
+              help="End hour ET")
+def manage_daemon(poll_interval: int, start_hour: int, end_hour: int):
+    """Run the price alert pipeline as a continuous daemon.
+
+    Replaces the Lambda-based pipeline. Uses yfinance for price data
+    when EODHD is unavailable.
+    """
+    from cli.env_loader import load_env
+    load_env()
+
+    from modules.manage.handler import _handle_intraday
+
+    click.echo("Manage daemon started")
+    click.echo(f"  Window: {start_hour}:00 - {end_hour}:00 ET")
+    click.echo(f"  Poll interval: {poll_interval}s")
+
+    try:
+        while True:
+            now_et = datetime.now(ET)
+
+            # No work on weekends
+            if now_et.weekday() >= 5:
+                _time.sleep(600)
+                continue
+
+            # Outside market hours
+            if now_et.hour < start_hour or now_et.hour >= end_hour:
+                _time.sleep(60)
+                continue
+
+            try:
+                result = _handle_intraday()
+                checked = result.get("tickers_checked", 0)
+                alerts = result.get("alerts_generated", 0)
+                errors = result.get("errors", [])
+                click.echo(
+                    f"[{now_et.strftime('%H:%M:%S')}] "
+                    f"Checked {checked} tickers, {alerts} alerts"
+                    f"{f', {len(errors)} errors' if errors else ''}"
+                )
+            except Exception as e:
+                logger.error("Intraday check failed: %s", e, exc_info=True)
+
+            _time.sleep(poll_interval)
+
+    except KeyboardInterrupt:
+        click.echo("\nManage daemon stopped.")

--- a/src/cli/queue_capacity.py
+++ b/src/cli/queue_capacity.py
@@ -162,12 +162,14 @@ class CapacityTracker:
         if not check_analyst_capacity():
             return False
 
-        # Telemetry-based capacity check (80% target)
+        # Telemetry-based capacity check — only gate if calibrated (have
+        # hit a real rate limit before). Pre-calibration, run uncapped to
+        # discover the true limit.
         try:
             from cli.telemetry import get_capacity_estimate
             cap = get_capacity_estimate()
-            if cap.get("at_target", False):
-                return False  # At or above 80% — stop
+            if cap.get("calibrated", False) and cap.get("at_target", False):
+                return False  # Calibrated and at/above 80% — stop
         except Exception:
             pass  # Telemetry not available, fall back to other checks
 

--- a/src/cli/queue_daemon.py
+++ b/src/cli/queue_daemon.py
@@ -100,7 +100,7 @@ def _run_queue_job(task: QueueTask, workspace: Path) -> tuple[bool, str, list[st
                     found.append(rel)
 
     missing_required = REQUIRED_ARTIFACTS - {f for f in found}
-    success = result.returncode == 0 and not missing_required
+    success = not result_json.get("is_error", False) and not missing_required
 
     # Read summary if it exists
     summary_text = ""

--- a/src/cli/queue_daemon.py
+++ b/src/cli/queue_daemon.py
@@ -53,6 +53,49 @@ def _save_state(state: QueueState) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Memo persistence
+# ---------------------------------------------------------------------------
+
+
+def _persist_to_ticker_memo(task: QueueTask, workspace: Path) -> None:
+    """Copy queue research results to the ticker's workspace and sync to S3.
+
+    Maps summary.md → memo.md, summary.yaml → memo.yaml so that queue
+    research updates the canonical ticker memo.
+    """
+    import shutil
+
+    from cli.s3 import get_s3_client, upload_file
+
+    repo_root = find_repo_root()
+    s3 = get_s3_client()
+
+    for ticker in task.tickers:
+        ticker_dir = repo_root / "workspace" / ticker
+        ticker_dir.mkdir(parents=True, exist_ok=True)
+
+        # Copy summary → memo (and any other research artifacts)
+        copied = 0
+        mapping = {"summary.md": "memo.md", "summary.yaml": "memo.yaml"}
+        for src_name, dst_name in mapping.items():
+            src = workspace / src_name
+            if src.exists():
+                shutil.copy2(src, ticker_dir / dst_name)
+                upload_file(s3, ticker_dir / dst_name, f"data/research/{ticker}/{dst_name}")
+                copied += 1
+
+        # Also copy any analyst .md files
+        for f in workspace.iterdir():
+            if f.is_file() and f.suffix == ".md" and f.name not in ("summary.md", "CLAUDE.md"):
+                shutil.copy2(f, ticker_dir / f.name)
+                upload_file(s3, ticker_dir / f.name, f"data/research/{ticker}/{f.name}")
+                copied += 1
+
+        if copied:
+            logger.info("Persisted %d file(s) to workspace/%s and S3", copied, ticker)
+
+
+# ---------------------------------------------------------------------------
 # Job execution
 # ---------------------------------------------------------------------------
 
@@ -222,6 +265,13 @@ def run_daemon(
                                 click.echo(f"  Synced {uploaded} artifact(s) to S3")
                         except Exception as e:
                             logger.error("S3 sync failed for #%d: %s", issue_num, e)
+
+                        # Persist results to ticker memo if this is ticker research
+                        if success and task.tickers:
+                            try:
+                                _persist_to_ticker_memo(task, workspace)
+                            except Exception as e:
+                                logger.error("Memo persist failed for #%d: %s", issue_num, e)
 
                     # Send notification
                     try:

--- a/src/cli/queue_prompt.py
+++ b/src/cli/queue_prompt.py
@@ -98,12 +98,28 @@ Task type: {task.task_type.value}
 
 ---
 {context_section}{links_section}{mcp_section}{data_section}
+## Execution Model — Codex MCP
+
+You MUST delegate the actual research work to the Codex MCP tool (`mcp__codex-cli__codex`).
+
+**How to use it:**
+1. Read the task description and any context files yourself first
+2. Construct a detailed prompt that includes all relevant context
+3. Call `mcp__codex-cli__codex` with:
+   - `prompt`: Your constructed research prompt (include the full task, context, and output requirements)
+   - `workingDirectory`: The current workspace path
+   - `fullAuto`: true
+4. Review codex's output and verify the required artifacts were produced
+5. If artifacts are missing or incomplete, call codex again with follow-up instructions
+
+**Why:** Codex is faster and cheaper for research-heavy tasks. You are the orchestrator — read context, construct prompts, delegate to codex, verify output.
+
 ## Praxis System Context
 
 You are running inside the praxis-copilot investment research system. Key facts:
 - Existing research for any ticker can be found in `data/` if it was staged
 - Use MCP tools for financial data if configured (see above)
-- Web search and web fetch are available for external research
+- Web search and web fetch are available for external research via codex
 - Images in `context/` can be read directly (you are multimodal)
 - Be thorough but concise. Lead with findings, not setup.
 

--- a/src/cli/queue_workspace.py
+++ b/src/cli/queue_workspace.py
@@ -17,6 +17,26 @@ from cli.s3 import download_file, get_s3_client, list_prefix, upload_file
 
 logger = logging.getLogger(__name__)
 
+CODEX_BIN = "/opt/homebrew/bin/codex"
+
+
+def _ensure_codex_mcp(workspace: Path) -> None:
+    """Add codex-cli MCP server to the workspace .mcp.json."""
+    mcp_path = workspace / ".mcp.json"
+    if mcp_path.exists():
+        try:
+            config = json.loads(mcp_path.read_text())
+        except Exception:
+            config = {"mcpServers": {}}
+    else:
+        config = {"mcpServers": {}}
+
+    config.setdefault("mcpServers", {})["codex-cli"] = {
+        "command": CODEX_BIN,
+        "args": ["--mcp"],
+    }
+    mcp_path.write_text(json.dumps(config, indent=2))
+
 
 def setup_workspace(task: QueueTask) -> Path:
     """Create and populate a workspace for a queue task.
@@ -51,6 +71,9 @@ def setup_workspace(task: QueueTask) -> Path:
         QueueTaskType.COMPARATIVE,
     ):
         has_mcp, data_manifest = _stage_ticker_data(task, workspace)
+
+    # Ensure codex-cli MCP is configured in workspace
+    _ensure_codex_mcp(workspace)
 
     # Generate CLAUDE.md
     prompt = generate_queue_prompt(

--- a/src/cli/telemetry.py
+++ b/src/cli/telemetry.py
@@ -261,7 +261,7 @@ def get_capacity_estimate() -> dict:
     # Default budget estimates (conservative, pre-calibration)
     window_budget_tokens = cal.get("estimated_window_budget_tokens", 300_000)
     window_budget_cost = cal.get("estimated_window_budget_cost", 30.0)
-    calibrated = "estimated_window_budget_tokens" in cal
+    calibrated = "last_rate_limit" in cal
 
     # Adaptive budget expansion: if no rate limits in last 8h, bump by 10%
     last_rl = cal.get("last_rate_limit")

--- a/src/modules/manage/intraday.py
+++ b/src/modules/manage/intraday.py
@@ -50,24 +50,35 @@ def check_move_from_close(
     direction = "up" if price_data.change_pct > 0 else "down"
     alert_type = AlertType.PRICE_BREACH_UP if direction == "up" else AlertType.PRICE_BREACH_DOWN
 
-    for b in range(1, band + 1):
-        if b in ticker_state.close_bands_fired:
-            continue
-        ticker_state.close_bands_fired.append(b)
-        threshold_pct = b * step
-        severity = Severity.HIGH if threshold_pct >= step * 2 else Severity.MEDIUM
-        alerts.append(Alert(
-            ticker=price_data.ticker,
-            timestamp=now,
-            alert_type=alert_type,
-            severity=severity,
-            details={
-                "change_pct": price_data.change_pct,
-                "threshold_pct": threshold_pct,
-                "price": price_data.price,
-                "previous_close": price_data.previous_close,
-            },
-        ))
+    # Only fire the highest unfired band — no stacking
+    highest_unfired = None
+    for b in range(band, 0, -1):
+        if b not in ticker_state.close_bands_fired:
+            highest_unfired = b
+            break
+
+    if highest_unfired is None:
+        return alerts
+
+    # Mark all bands up to the highest as fired
+    for b in range(1, highest_unfired + 1):
+        if b not in ticker_state.close_bands_fired:
+            ticker_state.close_bands_fired.append(b)
+
+    threshold_pct = highest_unfired * step
+    severity = Severity.HIGH if threshold_pct >= step * 2 else Severity.MEDIUM
+    alerts.append(Alert(
+        ticker=price_data.ticker,
+        timestamp=now,
+        alert_type=alert_type,
+        severity=severity,
+        details={
+            "change_pct": price_data.change_pct,
+            "threshold_pct": threshold_pct,
+            "price": price_data.price,
+            "previous_close": price_data.previous_close,
+        },
+    ))
 
     return alerts
 


### PR DESCRIPTION
## Summary
- Fix NEUTRAL alerts leaking through scanner alert filter
- Add alerts to `scan_unanalyzed()` backfill path (OFAL BUY 0.62 was missed today)
- Add `praxis scanner show <TICKER>` to view analysis without digging through S3
- Fix yfinance breaking price charts (multi-level columns + thread-safety)
- Improve HTML report skipped section: timestamps, source type labels, prescreen NEGATIVE distinction
- Daemon report regen: proper error logging + fallback to chartless report
- Launchd: ThrottleInterval + ExitTimeOut on all 4 plists to survive restarts
- Health check script: `scripts/daemon-health.sh` re-enables disabled daemons

## Test plan
- [ ] `praxis scanner show PFSA` — should display analysis JSON
- [ ] `praxis scanner show HASH.V` — should show prescreen NEGATIVE info
- [ ] `praxis filing-research report` — verify timestamps, source types, prescreen rows in skipped section
- [ ] Price charts should show different data per ticker (not identical)
- [ ] `./scripts/daemon-health.sh` — all 4 daemons should show OK
- [ ] Monitor next scan cycle: NEUTRAL alerts should NOT be emailed, backfill items should trigger alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)